### PR TITLE
QR code do Auto-cadastro, coluna Paciente nas Consultas e correção do filtro no WebKit

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -123,6 +123,12 @@ de modal (`tw-animate-css`), o ponto pulsante do microfone gravando. Sob
   penúltimo; o último é `BreadcrumbPage`).
 - Um único `<main>` na página (o `SidebarInset` é `div`).
 - Rodapé em `text-xs text-muted-foreground`, sem borda.
+- Ação global do cabeçalho (`BotaoAutoCadastro`): à direita (`ml-auto`),
+  `Button outline size="sm"` com ícone `QrCode` e o rótulo "Auto-cadastro" —
+  abre a modal do QR code do Auto-cadastro. É a única ação da moldura; ações
+  de página ficam no `CabecalhoPagina`. Não use botão flutuante para isso:
+  ele cobriria a barra "Salvar" grudada dos formulários e a paginação das
+  tabelas.
 
 ### 3.2 Cabeçalho de página (`CabecalhoPagina`)
 
@@ -197,6 +203,13 @@ são um par (o painel desfoca o véu): mexer no alfa de um muda o outro. A lista
 do filtro é `glass-frosted rounded-xl p-1` com opções `rounded-lg` e estados
 hover/focus/`aria-selected` em `bg-accent`.
 
+A modal do QR code (`ModalAutoCadastro`, `sm:max-w-md`) é a única exceção à
+regra dos tokens: o QR é preto sobre branco dentro do próprio SVG, com zona de
+silêncio de 2 módulos — exigência da leitura pela câmera, não uma superfície
+do tema. Em volta dele, `rounded-xl border-glass-border`; o endereço por
+extenso vai em `font-mono text-sm text-muted-foreground`; os erros usam
+`AvisoErro` seguido de um `Button outline` "Tentar de novo".
+
 ### 3.9 Painéis da Consulta (`PainelConsulta`)
 
 Conteúdo e Notas são dois cartões iguais: cabeçalho (título = `<label>` do
@@ -267,6 +280,8 @@ Conciso, confiante, claro e cordial — na linguagem de `CONTEXT.md`
   `tabIndex`.
 - Duas metáforas ao mesmo tempo (cartão chapado com sombra dura ao lado de
   vidro).
+- Botão flutuante no canto da tela: cobre a barra "Salvar" grudada e a
+  paginação; ação global vai ao cabeçalho (§3.1).
 
 ## 7. Checklist de QA (revisão de código)
 

--- a/docs/especificacao.md
+++ b/docs/especificacao.md
@@ -129,6 +129,14 @@ Página responsiva para cadastro e edição de pacientes.
 - **Após o envio**: tela de confirmação ("Cadastro recebido!") e retorno ao formulário em branco, pronto para o próximo paciente.
 - O Auto-cadastro **só cria** pacientes — nunca edita um cadastro existente.
 
+**Chegar ao Modo tablet — QR code (no Modo desktop):**
+
+- O cabeçalho do Modo desktop tem, em toda tela, o botão **"Auto-cadastro"** (ícone de QR code) na extremidade direita. Ele abre a modal **"Auto-cadastro no tablet"**.
+- A modal mostra o **QR code** do endereço do servidor local (`http://<IP-do-computador>:8738`), o mesmo endereço por extenso (para digitar, se preciso) e os passos: o tablet precisa estar no Wi-Fi do consultório; tocar no link que a câmera mostra; salvar a página nos favoritos — o endereço vale enquanto o Ebers estiver aberto e, se o favorito parar de abrir, basta ler o código de novo.
+- Quando o computador tem mais de um endereço (Wi-Fi e cabo, VPN, compartilhamento de internet), o sistema **escolhe sozinho**: um endereço da rede local, de preferência o pelo qual o computador sai para a rede. **Nunca há escolha de rede na tela.**
+- O endereço é consultado a cada abertura da modal. Se o servidor não subiu (porta ocupada), a modal avisa *"O Auto-cadastro não está no ar. Feche e abra o Ebers de novo."*; se o computador não está em nenhuma rede local, *"Este computador não está conectado a nenhuma rede. Conecte-o ao Wi-Fi do consultório."* — ambos com o botão "Tentar de novo".
+- O QR code aponta para o endereço fixo, sem código de uso único: quem chega por ele cai no Modo tablet como qualquer navegador da rede ([ADR-0003](./adr/0003-rede-local-sem-autenticacao.md)).
+
 **Modo desktop (terapeuta):**
 
 - Todos os campos e funcionalidades estão disponíveis.
@@ -320,7 +328,7 @@ Cada movimento registra data/hora, tipo, quantidade e referência/motivo.
 ### 4.1 Estrutura do layout
 
 - **Sidebar** (menu lateral à esquerda)
-- **Cabeçalho**: breadcrumb
+- **Cabeçalho**: breadcrumb e, à direita, o botão "Auto-cadastro" (QR code para o tablet — seção 1.3)
 - **Corpo**: título da página + conteúdo
 - **Rodapé**
 
@@ -365,6 +373,7 @@ O app desktop embute um **servidor HTTP local** (sugestão: Axum, no backend Rus
 - O servidor expõe **rotas REST** equivalentes aos Tauri Commands apenas para os fluxos usados no Auto-cadastro, já que `invoke()` não está disponível fora do webview Tauri. A lógica de negócio pode ser duplicada entre o Command e a rota HTTP quando necessário.
 - **Sem autenticação** — ver [ADR-0003](./adr/0003-rede-local-sem-autenticacao.md).
 - O frontend detecta o contexto de execução via `window.__TAURI__` (presente = app desktop; ausente = navegador externo) para decidir se aplica o modo tablet — mesma SPA, sem bundle separado. Consequência aceita: **qualquer** navegador externo (inclusive o celular da terapeuta) cai no modo tablet.
+- O app descobre o próprio endereço IPv4 na rede local (comando Tauri `endereco_auto_cadastro`, backend Rust) e o expõe como QR code na modal do cabeçalho (seção 1.3). O servidor abre a porta de forma síncrona na inicialização, então o app sabe desde o início se o Auto-cadastro está no ar — é o que permite à modal avisar quando não está.
 
 ### 5.2 Banco de dados
 

--- a/docs/operacao.md
+++ b/docs/operacao.md
@@ -7,10 +7,21 @@ Guia para a terapeuta.
 Com o Ebers aberto, qualquer navegador na mesma rede Wi-Fi do consultório
 mostra o Auto-cadastro — sem instalar nada no tablet:
 
-1. Descubra o IP do computador do consultório (macOS: Ajustes do Sistema →
-   Wi-Fi → Detalhes; Windows: Configurações → Rede e Internet).
-2. No navegador do tablet, acesse `http://IP-do-computador:8738` (ex.:
-   `http://192.168.0.10:8738`) e salve nos favoritos.
+1. No Ebers, clique em **Auto-cadastro** (o botão com o código, no canto
+   direito do cabeçalho). Abre a janela "Auto-cadastro no tablet".
+2. Com o tablet no Wi-Fi do consultório, aponte a câmera dele para o código
+   e toque no link que aparece.
+3. Salve a página nos favoritos do tablet: o endereço continua valendo
+   enquanto o Ebers estiver aberto no computador.
+
+Se um dia o favorito parar de abrir (o roteador pode ter dado outro endereço
+ao computador), abra a janela de novo e leia o código outra vez. O endereço
+também aparece por extenso embaixo do código (algo como
+`http://192.168.0.10:8738`), se preferir digitá-lo no navegador do tablet.
+
+> Se a janela avisar que o Auto-cadastro não está no ar, feche e abra o
+> Ebers de novo. Se avisar que o computador não está em nenhuma rede,
+> conecte-o ao Wi-Fi do consultório e clique em "Tentar de novo".
 
 Pela rede só existe o formulário de Auto-cadastro; as demais telas ficam
 restritas ao app no computador

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
         "lucide-react": "^1.30.0",
+        "qrcode.react": "^4.2.0",
         "radix-ui": "^1.6.7",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -9315,6 +9316,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/qs": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
     "lucide-react": "^1.30.0",
+    "qrcode.react": "^4.2.0",
     "radix-ui": "^1.6.7",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -869,12 +869,36 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -892,11 +916,22 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core",
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.119",
 ]
@@ -930,6 +965,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -1111,6 +1177,7 @@ dependencies = [
  "axum",
  "block2",
  "image",
+ "local-ip-address",
  "objc2",
  "objc2-avf-audio",
  "objc2-foundation",
@@ -1609,6 +1676,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cf442baaabe4213ce7d1239afc26c039180b6456da2cededa316ae2c8a77a77"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -2424,6 +2502,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
+name = "local-ip-address"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa08fb2b1ec3ea84575e94b489d06d4ce0cbf052d12acd515838f50e3c3d63e3"
+dependencies = [
+ "libc",
+ "neli",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,6 +2655,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "neli"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9786d56d972959e1408b6a93be6af13b9c1392036c5c1fafa08a1b0c6ee87"
+dependencies = [
+ "bitflags 2.13.1",
+ "byteorder",
+ "derive_builder",
+ "getset",
+ "libc",
+ "log",
+ "neli-proc-macros",
+ "parking_lot",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d8d08c6e98f20a62417478ebf7be8e1425ec9acecc6f63e22da633f6b71609"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3891,7 +4009,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,9 @@ image = { version = "0.25", default-features = false, features = ["jpeg", "png",
 # Servidor HTTP local do Auto-cadastro (spec 5.1, ADR-0003).
 axum = "0.8"
 tokio = { version = "1", features = ["rt-multi-thread", "net", "macros"] }
+# Endereços IPv4 da máquina na rede local, para o QR code do Auto-cadastro
+# (issue #21): a modal mostra o endereço que o tablet deve abrir.
+local-ip-address = "0.6.13"
 # Acesso direto ao ebers.db nas rotas do Auto-cadastro. Mesma versão de
 # libsqlite3-sys usada pelo sqlx do tauri-plugin-sql (chave `links`: só pode
 # haver uma no grafo).

--- a/src-tauri/src/endereco.rs
+++ b/src-tauri/src/endereco.rs
@@ -1,0 +1,263 @@
+//! Endereço do Auto-cadastro na rede local (issue #21): o que o QR code da
+//! modal "Auto-cadastro no tablet" codifica. A máquina pode ter vários
+//! endereços IPv4 ao mesmo tempo (Wi-Fi, Ethernet, VPN, compartilhamento de
+//! internet); a escolha é automática e a terapeuta nunca vê uma opção de rede.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, UdpSocket};
+
+use serde::Serialize;
+
+use crate::servidor::{EstadoDoServidor, PORTA};
+
+/// Resposta do comando `endereco_auto_cadastro`, como a modal a lê
+/// (src/db/servidor.ts). Servidor fora do ar prevalece sobre sem rede: com a
+/// porta fechada, endereço nenhum serviria.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(tag = "estado", rename_all = "kebab-case")]
+pub enum EnderecoAutoCadastro {
+    NoAr { url: String },
+    ForaDoAr,
+    SemRede,
+}
+
+/// Um endereço IPv4 da máquina e o nome da interface que o carrega.
+pub type EnderecoDaMaquina = (String, Ipv4Addr);
+
+/// O que a modal do QR code mostra agora: relido a cada abertura, porque o
+/// endereço muda quando a máquina troca de rede.
+pub fn endereco_auto_cadastro(estado: &EstadoDoServidor) -> EnderecoAutoCadastro {
+    resolver(estado.no_ar(), &enderecos_da_maquina(), endereco_de_saida())
+}
+
+/// Decide a resposta a partir do estado do servidor e dos endereços da
+/// máquina (`saida` é o endereço pelo qual ela sai para a rede, se conhecido).
+pub fn resolver(
+    no_ar: bool,
+    enderecos: &[EnderecoDaMaquina],
+    saida: Option<Ipv4Addr>,
+) -> EnderecoAutoCadastro {
+    if !no_ar {
+        return EnderecoAutoCadastro::ForaDoAr;
+    }
+    match escolher(enderecos, saida) {
+        Some(ip) => EnderecoAutoCadastro::NoAr {
+            url: url_do_auto_cadastro(ip),
+        },
+        None => EnderecoAutoCadastro::SemRede,
+    }
+}
+
+/// A URL que o tablet abre — porta fixa (servidor.rs), para o favorito do
+/// navegador sobreviver aos reinícios do app.
+pub fn url_do_auto_cadastro(ip: Ipv4Addr) -> String {
+    format!("http://{ip}:{PORTA}")
+}
+
+/// Escolhe, entre os endereços da máquina, o que o tablet deve abrir: um da
+/// rede local — de preferência o pelo qual a máquina sai para a rede e, sem
+/// esse, o da interface com mais cara de Wi-Fi ou Ethernet do consultório.
+pub fn escolher(enderecos: &[EnderecoDaMaquina], saida: Option<Ipv4Addr>) -> Option<Ipv4Addr> {
+    let mut candidatos: Vec<&EnderecoDaMaquina> = enderecos
+        .iter()
+        .filter(|(_, ip)| na_rede_local(*ip))
+        .collect();
+    if let Some(saida) = saida.filter(|saida| candidatos.iter().any(|(_, ip)| ip == saida)) {
+        return Some(saida);
+    }
+    candidatos.sort_by_key(|(nome, _)| (prioridade_da_interface(nome), nome.to_ascii_lowercase()));
+    candidatos.first().map(|(_, ip)| *ip)
+}
+
+/// Endereço que um tablet no Wi-Fi do consultório alcança: as faixas privadas
+/// (RFC 1918 — 10/8, 172.16/12 e 192.168/16). Ficam de fora o loopback, os
+/// link-local (169.254/16) e a faixa de túneis 100.64/10 (Tailscale,
+/// operadoras) — nenhum deles está nas faixas privadas.
+fn na_rede_local(ip: Ipv4Addr) -> bool {
+    ip.is_private()
+}
+
+/// Desempate quando não se sabe por onde a máquina sai: Wi-Fi e Ethernet
+/// (`en*` no macOS, `eth*`/`enp*`/`wl*` no Linux, "Ethernet"/"Wi-Fi" no
+/// Windows) primeiro; pontes, túneis e redes virtuais por último.
+fn prioridade_da_interface(nome: &str) -> u8 {
+    const VIRTUAIS: [&str; 11] = [
+        "bridge", "utun", "tun", "tap", "veth", "docker", "vmnet", "vbox", "awdl", "llw", "ap",
+    ];
+    const FISICAS: [&str; 5] = ["en", "eth", "wl", "wi-fi", "wifi"];
+    let nome = nome.to_ascii_lowercase();
+    if VIRTUAIS.iter().any(|prefixo| nome.starts_with(prefixo)) {
+        2
+    } else if FISICAS.iter().any(|prefixo| nome.starts_with(prefixo)) {
+        0
+    } else {
+        1
+    }
+}
+
+/// Endereços IPv4 de todas as interfaces da máquina, com o nome de cada uma.
+fn enderecos_da_maquina() -> Vec<EnderecoDaMaquina> {
+    local_ip_address::list_afinet_netifas()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|(nome, ip)| match ip {
+            IpAddr::V4(ip) => Some((nome, ip)),
+            IpAddr::V6(_) => None,
+        })
+        .collect()
+}
+
+/// O endereço pelo qual a máquina sai para a rede — o mesmo que o roteador
+/// do consultório enxerga. Um `connect` de UDP não envia pacote nenhum: só
+/// pede ao sistema a rota (e o endereço local) que ele usaria para aquele
+/// destino. Sem rota padrão (máquina sem roteador), volta `None` e o
+/// desempate por nome de interface decide.
+fn endereco_de_saida() -> Option<Ipv4Addr> {
+    let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
+    socket.connect(SocketAddr::from(([1, 1, 1, 1], 53))).ok()?;
+    match socket.local_addr().ok()?.ip() {
+        IpAddr::V4(ip) => Some(ip),
+        IpAddr::V6(_) => None,
+    }
+}
+
+#[cfg(test)]
+mod testes {
+    use super::*;
+
+    fn endereco(nome: &str, ip: [u8; 4]) -> EnderecoDaMaquina {
+        (nome.to_string(), Ipv4Addr::from(ip))
+    }
+
+    #[test]
+    fn servidor_fora_do_ar_prevalece_mesmo_com_rede() {
+        let enderecos = [endereco("en0", [192, 168, 0, 10])];
+
+        assert_eq!(
+            resolver(false, &enderecos, None),
+            EnderecoAutoCadastro::ForaDoAr
+        );
+    }
+
+    #[test]
+    fn sem_endereco_na_rede_local_e_sem_rede() {
+        assert_eq!(resolver(true, &[], None), EnderecoAutoCadastro::SemRede);
+    }
+
+    #[test]
+    fn no_ar_monta_a_url_com_a_porta_fixa() {
+        let enderecos = [endereco("en0", [192, 168, 0, 10])];
+
+        assert_eq!(
+            resolver(true, &enderecos, None),
+            EnderecoAutoCadastro::NoAr {
+                url: "http://192.168.0.10:8738".into()
+            }
+        );
+    }
+
+    #[test]
+    fn loopback_link_local_e_tuneis_nao_servem_para_o_tablet() {
+        // Nenhum deles é alcançável pelo Wi-Fi do consultório: loopback só
+        // vale na própria máquina, link-local não passa por roteador e a
+        // faixa 100.64/10 é de túneis (Tailscale, operadoras).
+        let enderecos = [
+            endereco("lo0", [127, 0, 0, 1]),
+            endereco("awdl0", [169, 254, 10, 2]),
+            endereco("utun3", [100, 64, 0, 7]),
+        ];
+
+        assert_eq!(
+            resolver(true, &enderecos, None),
+            EnderecoAutoCadastro::SemRede
+        );
+    }
+
+    #[test]
+    fn prefere_o_endereco_pelo_qual_a_maquina_sai_para_a_rede() {
+        let enderecos = [
+            endereco("en0", [192, 168, 0, 10]),
+            endereco("en5", [10, 0, 0, 4]),
+        ];
+
+        assert_eq!(
+            escolher(&enderecos, Some(Ipv4Addr::new(10, 0, 0, 4))),
+            Some(Ipv4Addr::new(10, 0, 0, 4))
+        );
+    }
+
+    #[test]
+    fn saida_por_um_tunel_nao_conta_e_a_rede_local_ganha() {
+        // VPN de túnel completo: a rota padrão sai pelo utun, mas o tablet
+        // só chega pelo Wi-Fi.
+        let enderecos = [
+            endereco("en0", [192, 168, 0, 10]),
+            endereco("utun4", [100, 100, 1, 1]),
+        ];
+
+        assert_eq!(
+            escolher(&enderecos, Some(Ipv4Addr::new(100, 100, 1, 1))),
+            Some(Ipv4Addr::new(192, 168, 0, 10))
+        );
+    }
+
+    #[test]
+    fn sem_saida_conhecida_wifi_e_ethernet_vem_antes_de_pontes_e_tuneis() {
+        let enderecos = [
+            endereco("bridge100", [192, 168, 2, 1]),
+            endereco("utun2", [10, 8, 0, 2]),
+            endereco("en1", [192, 168, 0, 10]),
+        ];
+
+        assert_eq!(
+            escolher(&enderecos, None),
+            Some(Ipv4Addr::new(192, 168, 0, 10))
+        );
+    }
+
+    #[test]
+    fn nomes_de_interface_do_windows_e_do_linux_tambem_sao_reconhecidos() {
+        let windows = [
+            endereco("vEthernet (Default Switch)", [172, 20, 0, 1]),
+            endereco("Wi-Fi", [192, 168, 0, 10]),
+        ];
+        let linux = [
+            endereco("docker0", [172, 17, 0, 1]),
+            endereco("wlp2s0", [192, 168, 0, 11]),
+        ];
+
+        assert_eq!(
+            escolher(&windows, None),
+            Some(Ipv4Addr::new(192, 168, 0, 10))
+        );
+        assert_eq!(escolher(&linux, None), Some(Ipv4Addr::new(192, 168, 0, 11)));
+    }
+
+    #[test]
+    fn resposta_serializa_como_a_modal_espera() {
+        // O contrato com src/db/servidor.ts: campo `estado` em kebab-case.
+        let no_ar = EnderecoAutoCadastro::NoAr {
+            url: "http://192.168.0.10:8738".into(),
+        };
+
+        assert_eq!(
+            serde_json::to_value(no_ar).expect("serializar"),
+            serde_json::json!({ "estado": "no-ar", "url": "http://192.168.0.10:8738" })
+        );
+        assert_eq!(
+            serde_json::to_value(EnderecoAutoCadastro::ForaDoAr).expect("serializar"),
+            serde_json::json!({ "estado": "fora-do-ar" })
+        );
+        assert_eq!(
+            serde_json::to_value(EnderecoAutoCadastro::SemRede).expect("serializar"),
+            serde_json::json!({ "estado": "sem-rede" })
+        );
+    }
+
+    #[test]
+    fn servidor_nasce_fora_do_ar_ate_abrir_a_porta() {
+        assert_eq!(
+            endereco_auto_cadastro(&EstadoDoServidor::default()),
+            EnderecoAutoCadastro::ForaDoAr
+        );
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ use tauri::Manager;
 use tauri_plugin_sql::{Migration, MigrationKind};
 
 pub mod cpf;
+pub mod endereco;
 pub mod fotos;
 pub mod previa;
 pub mod servidor;
@@ -98,6 +99,15 @@ fn remover_foto_paciente(app: tauri::AppHandle, arquivo: String) -> Result<(), S
     fotos::remover(&diretorio_de_fotos(&app)?, &arquivo)
 }
 
+/// O endereço que o tablet abre para o Auto-cadastro, ou por que não há um —
+/// a modal do QR code (issue #21) consulta a cada abertura.
+#[tauri::command]
+fn endereco_auto_cadastro(
+    estado: tauri::State<'_, servidor::EstadoDoServidor>,
+) -> endereco::EnderecoAutoCadastro {
+    endereco::endereco_auto_cadastro(&estado)
+}
+
 /// Nome do modelo Whisper disponível (ou nulo) — o frontend consulta antes de
 /// ligar o microfone, para avisar quando ainda não há modelo baixado.
 #[tauri::command]
@@ -171,12 +181,14 @@ pub fn run() {
                 .add_migrations(URL_BANCO, migracoes())
                 .build(),
         )
+        .manage(servidor::EstadoDoServidor::default())
         .manage(transcricao::Transcritor::default())
         .manage(previa::Previa::default())
         .invoke_handler(tauri::generate_handler![
             salvar_foto_paciente,
             carregar_foto_paciente,
             remover_foto_paciente,
+            endereco_auto_cadastro,
             modelo_de_transcricao,
             transcrever_audio,
             previa_disponibilidade,

--- a/src-tauri/src/servidor.rs
+++ b/src-tauri/src/servidor.rs
@@ -6,7 +6,10 @@
 //! consciente (ADR-0003): a rede física do consultório é considerada
 //! confiável e as rotas só permitem criação, nunca leitura ou edição.
 
+use std::net::SocketAddr;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -18,6 +21,24 @@ use serde::Deserialize;
 /// Porta fixa do servidor: a URL no tablet (favorito do navegador) não muda
 /// entre reinícios do app.
 pub const PORTA: u16 = 8738;
+
+/// Se o servidor está com a porta aberta — decidido em `iniciar`, antes de a
+/// janela aparecer, e consultado pela modal do QR code (endereco.rs). Nasce
+/// fora do ar: só o `bind` bem-sucedido o coloca no ar.
+#[derive(Clone, Default)]
+pub struct EstadoDoServidor {
+    no_ar: Arc<AtomicBool>,
+}
+
+impl EstadoDoServidor {
+    pub fn no_ar(&self) -> bool {
+        self.no_ar.load(Ordering::Relaxed)
+    }
+
+    fn marcar(&self, no_ar: bool) {
+        self.no_ar.store(no_ar, Ordering::Relaxed);
+    }
+}
 
 /// Caminhos que as rotas do Auto-cadastro usam para persistir.
 #[derive(Clone)]
@@ -72,27 +93,36 @@ pub fn rotas_auto_cadastro(estado: EstadoAutoCadastro) -> Router {
         .with_state(estado)
 }
 
-/// Sobe o servidor em segundo plano, junto com o app (lib.rs). Uma falha —
-/// porta ocupada, por exemplo — não derruba o modo desktop: fica no stderr e
-/// o Auto-cadastro volta no próximo início do app.
+/// Sobe o servidor junto com o app (lib.rs). Uma falha — porta ocupada, por
+/// exemplo — não derruba o modo desktop: fica no stderr, o `EstadoDoServidor`
+/// continua fora do ar (a modal do QR code avisa) e o Auto-cadastro volta no
+/// próximo início do app.
 pub fn iniciar(app: &tauri::AppHandle) -> Result<(), String> {
+    use tauri::Manager;
+
     let estado = EstadoAutoCadastro {
         caminho_banco: crate::caminho_do_banco(app)?,
         diretorio_fotos: crate::diretorio_de_fotos(app)?,
     };
     let rotas = rotas_auto_cadastro(estado).fallback_service(rotas_spa(app.clone()));
+    // Escuta a rede local inteira: é assim que o tablet chega (ADR-0003). A
+    // porta é aberta aqui mesmo, de forma síncrona, para o estado do servidor
+    // estar decidido antes de a janela aparecer.
+    let toda_a_rede = SocketAddr::from(([0, 0, 0, 0], PORTA));
+    let escuta = tauri::async_runtime::block_on(tokio::net::TcpListener::bind(toda_a_rede))
+        .map_err(|erro| format!("não conseguiu abrir a porta {PORTA}: {erro}"))?;
+    let estado_do_servidor = app.state::<EstadoDoServidor>().inner().clone();
+    estado_do_servidor.marcar(true);
+    match crate::endereco::endereco_auto_cadastro(&estado_do_servidor) {
+        crate::endereco::EnderecoAutoCadastro::NoAr { url } => {
+            println!("Auto-cadastro na rede local: {url}");
+        }
+        sem_endereco => println!("Auto-cadastro na rede local: {sem_endereco:?}"),
+    }
     tauri::async_runtime::spawn(async move {
-        // Escuta a rede local inteira: é assim que o tablet chega (ADR-0003).
-        let escuta = match tokio::net::TcpListener::bind(("0.0.0.0", PORTA)).await {
-            Ok(escuta) => escuta,
-            Err(erro) => {
-                eprintln!("Servidor do Auto-cadastro não conseguiu abrir a porta {PORTA}: {erro}");
-                return;
-            }
-        };
-        println!("Auto-cadastro na rede local: http://<IP-deste-computador>:{PORTA}");
         if let Err(erro) = axum::serve(escuta, rotas).await {
             eprintln!("Servidor do Auto-cadastro parou: {erro}");
+            estado_do_servidor.marcar(false);
         }
     });
     Ok(())

--- a/src/components/botao-auto-cadastro.tsx
+++ b/src/components/botao-auto-cadastro.tsx
@@ -1,0 +1,29 @@
+import { QrCode } from "lucide-react";
+import { useState } from "react";
+import { ModalAutoCadastro } from "@/components/modal-auto-cadastro";
+import { Button } from "@/components/ui/button";
+
+/**
+ * Ação global do cabeçalho do Modo desktop (issue #21): abre a modal com o QR
+ * code do Auto-cadastro para a terapeuta ler com o tablet. Vive no cabeçalho
+ * grudado, e não num botão flutuante, para não cobrir a barra "Salvar" dos
+ * formulários nem a paginação das tabelas (docs/design.md §3.1).
+ */
+export function BotaoAutoCadastro() {
+  const [aberta, setAberta] = useState(false);
+
+  return (
+    <>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setAberta(true)}
+      >
+        <QrCode aria-hidden="true" />
+        Auto-cadastro
+      </Button>
+      {aberta && <ModalAutoCadastro aoFechar={() => setAberta(false)} />}
+    </>
+  );
+}

--- a/src/components/modal-auto-cadastro.test.tsx
+++ b/src/components/modal-auto-cadastro.test.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { beforeEach, expect, test, vi } from "vitest";
+import {
+  programarComando,
+  programarErroDeComando,
+  reiniciarComandosFalsos,
+} from "@/testes/comandos-falsos";
+import { ModalAutoCadastro } from "./modal-auto-cadastro";
+
+// Fronteira do sistema: o comando Tauri que descobre o endereço do servidor
+// local (src-tauri/src/endereco.rs). A modal roda de verdade sobre o dublê.
+vi.mock("@tauri-apps/api/core", () => import("@/testes/comandos-falsos"));
+
+beforeEach(reiniciarComandosFalsos);
+
+const URL_DO_TABLET = "http://192.168.0.10:8738";
+
+function renderizarModal(aoFechar = vi.fn()) {
+  render(<ModalAutoCadastro aoFechar={aoFechar} />);
+  return aoFechar;
+}
+
+test("com o servidor no ar, mostra o QR code, o endereço em texto e os passos", async () => {
+  programarComando("endereco_auto_cadastro", {
+    estado: "no-ar",
+    url: URL_DO_TABLET,
+  });
+  renderizarModal();
+
+  expect(await screen.findByText(URL_DO_TABLET)).toBeInTheDocument();
+  expect(
+    screen.getByRole("heading", { name: "Auto-cadastro no tablet" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole("img", { name: "QR code do endereço do Auto-cadastro" }),
+  ).toBeInTheDocument();
+  expect(
+    screen.getAllByRole("listitem").map((passo) => passo.textContent),
+  ).toEqual([
+    "O tablet precisa estar no Wi-Fi do consultório.",
+    "Toque no link que aparece na câmera.",
+    "Salve a página nos favoritos: o endereço vale enquanto o Ebers estiver aberto. Se um dia o favorito parar de abrir, leia o código de novo.",
+  ]);
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});
+
+test("servidor fora do ar: aviso, e Tentar de novo consulta o endereço outra vez", async () => {
+  programarComando("endereco_auto_cadastro", { estado: "fora-do-ar" });
+  programarComando("endereco_auto_cadastro", {
+    estado: "no-ar",
+    url: URL_DO_TABLET,
+  });
+  renderizarModal();
+
+  expect(await screen.findByRole("alert")).toHaveTextContent(
+    "O Auto-cadastro não está no ar. Feche e abra o Ebers de novo.",
+  );
+  expect(
+    screen.queryByRole("img", { name: "QR code do endereço do Auto-cadastro" }),
+  ).not.toBeInTheDocument();
+
+  await userEvent.click(screen.getByRole("button", { name: "Tentar de novo" }));
+
+  expect(await screen.findByText(URL_DO_TABLET)).toBeInTheDocument();
+  expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+});
+
+test("sem rede: aviso para conectar o computador ao Wi-Fi do consultório", async () => {
+  programarComando("endereco_auto_cadastro", { estado: "sem-rede" });
+  renderizarModal();
+
+  expect(await screen.findByRole("alert")).toHaveTextContent(
+    "Este computador não está conectado a nenhuma rede. Conecte-o ao Wi-Fi do consultório.",
+  );
+  expect(
+    screen.getByRole("button", { name: "Tentar de novo" }),
+  ).toBeInTheDocument();
+});
+
+test("falha ao consultar o endereço: aviso genérico com Tentar de novo", async () => {
+  programarErroDeComando("endereco_auto_cadastro", new Error("ipc"));
+  renderizarModal();
+
+  expect(await screen.findByRole("alert")).toHaveTextContent(
+    "Não foi possível obter o endereço. Tente de novo.",
+  );
+  expect(
+    screen.getByRole("button", { name: "Tentar de novo" }),
+  ).toBeInTheDocument();
+});
+
+test("fechar a modal avisa quem a abriu", async () => {
+  programarComando("endereco_auto_cadastro", {
+    estado: "no-ar",
+    url: URL_DO_TABLET,
+  });
+  const aoFechar = renderizarModal();
+  await screen.findByText(URL_DO_TABLET);
+
+  await userEvent.click(screen.getByRole("button", { name: "Fechar" }));
+
+  expect(aoFechar).toHaveBeenCalled();
+});

--- a/src/components/modal-auto-cadastro.tsx
+++ b/src/components/modal-auto-cadastro.tsx
@@ -1,0 +1,153 @@
+import { QRCodeSVG } from "qrcode.react";
+import { useEffect, useState } from "react";
+import { AvisoErro } from "@/components/aviso";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { type EnderecoAutoCadastro, enderecoAutoCadastro } from "@/db/servidor";
+
+interface PropsModalAutoCadastro {
+  aoFechar: () => void;
+}
+
+type Carga =
+  | { estado: "carregando" }
+  | { estado: "pronto"; endereco: EnderecoAutoCadastro }
+  | { estado: "erro" };
+
+async function consultarEndereco(): Promise<Carga> {
+  try {
+    return { estado: "pronto", endereco: await enderecoAutoCadastro() };
+  } catch {
+    return { estado: "erro" };
+  }
+}
+
+/**
+ * Modal "Auto-cadastro no tablet" (spec 1.3; issue #21): o QR code do
+ * endereço do servidor local, para a terapeuta ler com a câmera do tablet do
+ * consultório. O endereço é consultado a cada abertura — ele muda quando o
+ * computador troca de rede — e de novo em "Tentar de novo".
+ */
+export function ModalAutoCadastro({ aoFechar }: PropsModalAutoCadastro) {
+  const [carga, setCarga] = useState<Carga>({ estado: "carregando" });
+
+  useEffect(() => {
+    let ativo = true;
+    consultarEndereco().then((carga) => {
+      if (ativo) setCarga(carga);
+    });
+    return () => {
+      ativo = false;
+    };
+  }, []);
+
+  async function tentarDeNovo() {
+    setCarga({ estado: "carregando" });
+    setCarga(await consultarEndereco());
+  }
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(aberto) => {
+        if (!aberto) aoFechar();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Auto-cadastro no tablet</DialogTitle>
+          <DialogDescription>
+            Aponte a câmera do tablet para o código: ele abre o formulário em
+            que o paciente preenche o próprio cadastro.
+          </DialogDescription>
+        </DialogHeader>
+
+        {carga.estado === "carregando" && (
+          <p className="text-sm text-muted-foreground">
+            Procurando o endereço…
+          </p>
+        )}
+
+        {carga.estado === "pronto" && carga.endereco.estado === "no-ar" && (
+          <CodigoDoEndereco url={carga.endereco.url} />
+        )}
+
+        {carga.estado === "pronto" &&
+          carga.endereco.estado === "fora-do-ar" && (
+            <Problema aoTentarDeNovo={tentarDeNovo}>
+              O Auto-cadastro não está no ar. Feche e abra o Ebers de novo.
+            </Problema>
+          )}
+
+        {carga.estado === "pronto" && carga.endereco.estado === "sem-rede" && (
+          <Problema aoTentarDeNovo={tentarDeNovo}>
+            Este computador não está conectado a nenhuma rede. Conecte-o ao
+            Wi-Fi do consultório.
+          </Problema>
+        )}
+
+        {carga.estado === "erro" && (
+          <Problema aoTentarDeNovo={tentarDeNovo}>
+            Não foi possível obter o endereço. Tente de novo.
+          </Problema>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** O QR code, o endereço por extenso (plano B para digitar) e os passos. */
+function CodigoDoEndereco({ url }: { url: string }) {
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col items-center gap-3">
+        {/* Preto sobre branco dentro do próprio SVG, com a zona de silêncio
+            (marginSize) que a leitura pela câmera exige: é um gráfico, não
+            uma superfície do tema — por isso não usa os tokens de vidro. */}
+        <div className="overflow-hidden rounded-xl border border-glass-border">
+          <QRCodeSVG
+            value={url}
+            size={224}
+            level="M"
+            marginSize={2}
+            role="img"
+            aria-label="QR code do endereço do Auto-cadastro"
+          />
+        </div>
+        <p className="font-mono text-sm text-muted-foreground">{url}</p>
+      </div>
+      <ol className="list-decimal space-y-1 pl-5 text-sm">
+        <li>O tablet precisa estar no Wi-Fi do consultório.</li>
+        <li>Toque no link que aparece na câmera.</li>
+        <li>
+          Salve a página nos favoritos: o endereço vale enquanto o Ebers estiver
+          aberto. Se um dia o favorito parar de abrir, leia o código de novo.
+        </li>
+      </ol>
+    </div>
+  );
+}
+
+/** No lugar do QR code: o que não deu e, se houver, o que fazer. */
+function Problema({
+  children,
+  aoTentarDeNovo,
+}: {
+  children: React.ReactNode;
+  aoTentarDeNovo: () => void;
+}) {
+  return (
+    <div className="flex flex-col items-start gap-3">
+      <AvisoErro className="w-full">{children}</AvisoErro>
+      <Button type="button" variant="outline" onClick={aoTentarDeNovo}>
+        Tentar de novo
+      </Button>
+    </div>
+  );
+}

--- a/src/db/servidor.ts
+++ b/src/db/servidor.ts
@@ -1,0 +1,25 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/**
+ * Fronteira com o comando Tauri do servidor local do Auto-cadastro
+ * (src-tauri/src/endereco.rs, issue #21): o endereço que o tablet abre — o
+ * que o QR code da modal "Auto-cadastro no tablet" codifica — ou por que não
+ * há um. O app escolhe o endereço sozinho quando a máquina tem vários; a
+ * terapeuta nunca escolhe rede.
+ */
+
+/**
+ * `no-ar`: o servidor abriu a porta e `url` é o endereço na rede local.
+ * `fora-do-ar`: a porta não abriu (ocupada, por exemplo) — só reabrir o app.
+ * `sem-rede`: a porta está aberta, mas o computador não tem endereço numa
+ * rede local que o tablet alcance.
+ */
+export type EnderecoAutoCadastro =
+  | { estado: "no-ar"; url: string }
+  | { estado: "fora-do-ar" }
+  | { estado: "sem-rede" };
+
+/** Relido a cada consulta: o endereço muda quando a máquina troca de rede. */
+export async function enderecoAutoCadastro(): Promise<EnderecoAutoCadastro> {
+  return await invoke<EnderecoAutoCadastro>("endereco_auto_cadastro");
+}

--- a/src/layout/layout-app.test.tsx
+++ b/src/layout/layout-app.test.tsx
@@ -1,13 +1,22 @@
 import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { Rotas } from "@/rotas";
+import {
+  programarComando,
+  reiniciarComandosFalsos,
+} from "@/testes/comandos-falsos";
 import { encerrarModoDesktop, simularModoDesktop } from "@/testes/modo-desktop";
 
 vi.mock("@tauri-apps/plugin-sql", () => import("@/testes/plugin-sql-vazio"));
+vi.mock("@tauri-apps/api/core", () => import("@/testes/comandos-falsos"));
 
 // Estas telas são o Modo desktop: o layout só aparece dentro do webview do app.
-beforeEach(simularModoDesktop);
+beforeEach(() => {
+  simularModoDesktop();
+  reiniciarComandosFalsos();
+});
 afterEach(encerrarModoDesktop);
 
 function renderizarApp(caminho = "/") {
@@ -71,4 +80,46 @@ test("o rodapé está presente", async () => {
 
   await screen.findByRole("heading", { name: "Pacientes" });
   expect(screen.getByRole("contentinfo")).toHaveTextContent("Ebers");
+});
+
+test("o cabeçalho tem o botão Auto-cadastro, que abre a modal com o QR code", async () => {
+  programarComando("endereco_auto_cadastro", {
+    estado: "no-ar",
+    url: "http://192.168.0.10:8738",
+  });
+  renderizarApp("/consultas");
+  await screen.findByRole("heading", { name: "Consultas" });
+
+  await userEvent.click(screen.getByRole("button", { name: "Auto-cadastro" }));
+
+  expect(
+    await screen.findByRole("dialog", { name: "Auto-cadastro no tablet" }),
+  ).toBeInTheDocument();
+  expect(
+    await screen.findByText("http://192.168.0.10:8738"),
+  ).toBeInTheDocument();
+});
+
+test("reabrir a modal consulta o endereço de novo", async () => {
+  // A máquina trocou de rede entre uma abertura e outra.
+  programarComando("endereco_auto_cadastro", {
+    estado: "no-ar",
+    url: "http://192.168.0.10:8738",
+  });
+  programarComando("endereco_auto_cadastro", {
+    estado: "no-ar",
+    url: "http://10.0.0.4:8738",
+  });
+  renderizarApp();
+  await screen.findByRole("heading", { name: "Pacientes" });
+
+  await userEvent.click(screen.getByRole("button", { name: "Auto-cadastro" }));
+  await screen.findByText("http://192.168.0.10:8738");
+  await userEvent.click(screen.getByRole("button", { name: "Fechar" }));
+  await userEvent.click(screen.getByRole("button", { name: "Auto-cadastro" }));
+
+  expect(await screen.findByText("http://10.0.0.4:8738")).toBeInTheDocument();
+  expect(
+    screen.queryByText("http://192.168.0.10:8738"),
+  ).not.toBeInTheDocument();
 });

--- a/src/layout/layout-app.tsx
+++ b/src/layout/layout-app.tsx
@@ -1,4 +1,5 @@
 import { Link, NavLink, Outlet, useLocation } from "react-router";
+import { BotaoAutoCadastro } from "@/components/botao-auto-cadastro";
 import { MarcaEbers } from "@/components/marca-ebers";
 import { PanoDeFundo } from "@/components/pano-de-fundo";
 import {
@@ -133,6 +134,11 @@ export function LayoutApp() {
                 )}
               </BreadcrumbList>
             </Breadcrumb>
+            {/* Ação global da moldura: o QR code do Auto-cadastro, ao alcance
+                em qualquer tela (issue #21). */}
+            <div className="ml-auto">
+              <BotaoAutoCadastro />
+            </div>
           </header>
 
           <main className="flex-1 px-6 py-6">

--- a/src/rotas.test.tsx
+++ b/src/rotas.test.tsx
@@ -35,6 +35,10 @@ test("sem window.__TAURI__, qualquer caminho cai no Auto-cadastro, sem menu", ()
   ).toBeInTheDocument();
   expect(screen.queryByRole("navigation")).not.toBeInTheDocument();
   expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  // O QR code é ferramenta da Terapeuta: só existe no cabeçalho do desktop.
+  expect(
+    screen.queryByRole("button", { name: "Auto-cadastro" }),
+  ).not.toBeInTheDocument();
 });
 
 test("no app desktop, /consultas/:id cai na página da consulta", async () => {


### PR DESCRIPTION
## Resumo

Leva para a `main` três commits da `dev`, cada um com a sua issue (`(#N)` na mensagem); este PR é o que fecha as issues.

### Auto-cadastro no tablet (#21, commit 9f40273)

O botão **"Auto-cadastro"** no cabeçalho do Modo desktop abre a modal "Auto-cadastro no tablet" com o QR code do endereço local (`http://IP:8738`) — o tablet chega ao Auto-cadastro lendo o código, sem que a terapeuta precise descobrir e digitar o IP do computador.

- Botão global no cabeçalho grudado (`outline sm`, ícone `QrCode`), presente em toda tela do Modo desktop e ausente no Modo tablet; botão flutuante no canto foi avaliado e descartado (cobriria a barra "Salvar" grudada dos formulários e a paginação das tabelas)
- Modal com o QR (`qrcode.react`, 224 px), o endereço por extenso (plano B para digitar) e os três passos — Wi-Fi do consultório, tocar no link da câmera, salvar nos favoritos; endereço relido a cada abertura e em "Tentar de novo"
- Backend: o servidor abre a porta de forma síncrona na inicialização e registra o resultado em `EstadoDoServidor`; o comando `endereco_auto_cadastro` devolve `no-ar` + url, `fora-do-ar` ou `sem-rede`, com escolha automática do endereço (faixas privadas RFC 1918, preferência pelo endereço de saída da máquina, desempate por nome de interface) — nenhum seletor na tela
- Avisos na modal quando o servidor não subiu (porta ocupada) ou o computador não está em nenhuma rede local
- Docs: spec (1.3, 4.1, 5.1), operação (o QR vira o caminho para o tablet) e design (§3.1, §3.8, anti-padrão do botão flutuante); glossário e ADRs intocados

Fora do escopo, com issue própria: a listagem de Pacientes se atualizar sozinha quando um cadastro chega do tablet (#22).

### Coluna Paciente na listagem de Consultas (#24, commit 2e52d5b)

A listagem mostrava a foto do paciente, mas não o nome. A coluna **"Paciente"** (nome completo) entra logo após a foto e vira a célula em destaque da linha; spec 2.4 atualizada. Ordenação, filtro, paginação e clique na linha não mudam.

### Filtro por paciente não aplicava a seleção no WebKit (#25, commit 1b5f95d)

Bug só no app (WKWebView): no WebKit um `<button>` não recebe foco ao ser clicado, então o `mousedown` na opção tirava o foco do campo com `relatedTarget` nulo, a lista fechava e a opção era desmontada antes do `click`. Reproduzido e diagnosticado no motor real com Playwright/WebKit; corrigido cancelando o `mousedown` das opções (o foco fica no campo, a seleção segue no `click`). Regressão em `filtro-paciente.test.tsx` imitando a sequência do WebKit.

## Verificação

- `npm run test:run`: 30 arquivos, **293 testes** passando
- `cargo test --manifest-path src-tauri/Cargo.toml`: **60 testes** passando
- `npm run lint` (biome), `tsc --noEmit`, `npm run contraste` e `vite build`: sem erros
- Loop Playwright/WebKit do filtro: vermelho antes da correção, verde depois (harness descartado, não versionado)
- Pendente de verificação manual no app empacotado: leitura do QR pela câmera do tablet a partir da tela do Mac (em `tauri dev` o Axum não serve a SPA)

Total: 353 testes.

## Issues fechadas

Closes #21
Closes #24
Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Axrm5ix6NQBVmNpGWAw8Gy