### PR TITLE
fix: Empacotamento do DMG falhava no macOS 26 com o volume ocupado

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -25,9 +25,11 @@ run = "npx drizzle-kit generate"
 description = "Empacota o app para macOS como binário universal (Intel + Apple Silicon)"
 # Universal e não só a arquitetura de quem constrói: cada fatia compila com o
 # próprio cfg, então a arm64 sai com o Metal e a x86_64 sem ele (ADR-0006).
+# O PATH antepõe scripts/shims: no macOS 26 o `hdiutil detach` da etapa do DMG
+# falha com "Recurso ocupado" e o script do Tauri não re-tenta (ver o shim).
 run = [
   "rustup target add aarch64-apple-darwin x86_64-apple-darwin",
-  "npm run tauri build -- --target universal-apple-darwin",
+  "PATH=\"$PWD/scripts/shims:$PATH\" npm run tauri build -- --target universal-apple-darwin",
 ]
 
 [tasks.icone]

--- a/scripts/shims/hdiutil
+++ b/scripts/shims/hdiutil
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Shim do hdiutil usado só pela task `mise run build:macos` (via PATH).
+#
+# Por quê: o bundle_dmg.sh que o Tauri embute (fork do create-dmg) desmonta o
+# volume logo depois do AppleScript do Finder, e nesse instante o macOS ainda
+# segura o volume ("Recurso ocupado"). O script só re-tenta quando o hdiutil
+# sai com código 16 (EBUSY clássico), mas no macOS 26 (Tahoe) o hdiutil foi
+# reescrito e devolve 2 — o build inteiro aborta na primeira tentativa.
+# O create-dmg upstream já corrigiu detectando "Resource busy" no texto, o que
+# aqui também falharia: a mensagem vem localizada em pt-BR.
+#
+# Este shim intercepta apenas `hdiutil detach`: re-tenta com espera crescente
+# e, em último caso, desmonta com -force (inofensivo aqui — o conteúdo do DMG
+# já foi todo escrito; quem segura o volume são leitores do sistema, como o
+# Spotlight). Qualquer outro subcomando é delegado intacto ao hdiutil real.
+# Pode ser removido quando o Tauri atualizar o fork do create-dmg.
+
+REAL=/usr/bin/hdiutil
+
+if [[ "$1" != "detach" ]]; then
+  exec "$REAL" "$@"
+fi
+
+for tentativa in 1 2 3 4 5; do
+  "$REAL" "$@" && exit 0
+  echo "hdiutil-shim: detach falhou (tentativa $tentativa/5), aguardando $((2 * tentativa))s..." >&2
+  sleep $((2 * tentativa))
+done
+
+echo "hdiutil-shim: desmontando com -force..." >&2
+exec "$REAL" "$@" -force


### PR DESCRIPTION
## Resumo

`mise run build:macos` compilava o app e morria na etapa final — "error running bundle_dmg.sh", sem mais detalhe. O script que o Tauri embute (fork do create-dmg) desmonta o volume do DMG logo depois do AppleScript que arruma a janela do Finder, e nesse instante o macOS ainda segura o volume ("Recurso ocupado"). O bloqueio é passageiro e o script até re-tenta — mas só quando o `hdiutil` sai com código 16 (EBUSY clássico); no macOS 26 o `hdiutil` foi reescrito e devolve **2**, então o build abortava na primeira tentativa. O upstream do create-dmg corrigiu detectando "Resource busy" no texto do erro, o que aqui também falharia (a mensagem vem localizada em pt-BR), e o CLI 2.11.4 do Tauri — o mais recente — ainda carrega o fork antigo.

Correção: `scripts/shims/hdiutil`, que a task `build:macos` antepõe ao PATH só nesse comando. O shim intercepta apenas o `detach` — até cinco tentativas com espera crescente e, em último caso, `-force` (inofensivo nesse ponto: o conteúdo do DMG já foi todo escrito; quem segura o volume são leitores do sistema, como o Spotlight). Qualquer outro subcomando passa intacto ao `/usr/bin/hdiutil`. Removível quando o Tauri atualizar o fork do create-dmg.

## Verificação

- `mise run build:macos` completo voltou a terminar com os dois bundles (`Ebers.app` e `Ebers_0.1.0_universal.dmg`), sem volume montado nem imagem temporária sobrando
- Nenhum código de aplicação mudou — não há testes novos

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Axrm5ix6NQBVmNpGWAw8Gy