### PR TITLE
Listagem de Pacientes se atualiza ao chegar um Auto-cadastro

### DIFF
--- a/docs/especificacao.md
+++ b/docs/especificacao.md
@@ -105,6 +105,8 @@ Página com tabela paginada (10 por página) de todos os pacientes cadastrados.
 
 **Filtro:** busca por nome do paciente, ignorando acentos e diferenças de caixa.
 
+**Atualização ao vivo:** um Auto-cadastro concluído no tablet aparece na listagem sem sair da página — o servidor local avisa o app (evento `paciente-cadastrado`) e a tabela é recarregada, preservando busca, ordenação e página. Sem polling e sem notificação visual além da linha nova aparecer.
+
 ### 1.3 Formulário de cadastro/edição de paciente
 
 Página responsiva para cadastro e edição de pacientes.

--- a/src-tauri/src/servidor.rs
+++ b/src-tauri/src/servidor.rs
@@ -5,6 +5,8 @@
 //! Paciente e receber a foto de perfil. Sem autenticação, por decisão
 //! consciente (ADR-0003): a rede física do consultório é considerada
 //! confiável e as rotas só permitem criação, nunca leitura ou edição.
+//! Cada Paciente gravado emite o evento `paciente-cadastrado` para o app
+//! (issue #22): é o que mantém a listagem de Pacientes do desktop em dia.
 
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -40,11 +42,21 @@ impl EstadoDoServidor {
     }
 }
 
-/// Caminhos que as rotas do Auto-cadastro usam para persistir.
+/// Evento Tauri emitido a cada Paciente gravado pelo Auto-cadastro — espelho
+/// de EVENTO_PACIENTE_CADASTRADO em src/db/eventos.ts. A listagem de
+/// Pacientes do desktop recarrega ao recebê-lo (issue #22).
+pub const EVENTO_PACIENTE_CADASTRADO: &str = "paciente-cadastrado";
+
+/// Caminhos que as rotas do Auto-cadastro usam para persistir, e o aviso que
+/// mantém o desktop em dia.
 #[derive(Clone)]
 pub struct EstadoAutoCadastro {
     pub caminho_banco: PathBuf,
     pub diretorio_fotos: PathBuf,
+    /// Chamado logo após gravar um Paciente — aviso sem carga: quem escuta
+    /// relê o banco. Em produção (`iniciar`) emite EVENTO_PACIENTE_CADASTRADO
+    /// com o `AppHandle`; os testes contam chamadas.
+    pub avisar_paciente_cadastrado: Arc<dyn Fn() + Send + Sync>,
 }
 
 /// Cadastro como o formulário do Modo tablet envia (src/db/auto-cadastro.ts):
@@ -103,6 +115,18 @@ pub fn iniciar(app: &tauri::AppHandle) -> Result<(), String> {
     let estado = EstadoAutoCadastro {
         caminho_banco: crate::caminho_do_banco(app)?,
         diretorio_fotos: crate::diretorio_de_fotos(app)?,
+        avisar_paciente_cadastrado: {
+            let app = app.clone();
+            Arc::new(move || {
+                use tauri::Emitter;
+                // Falha de emissão não interfere na resposta ao tablet: o
+                // cadastro já está gravado; a listagem se atualiza na próxima
+                // visita à página.
+                if let Err(erro) = app.emit(EVENTO_PACIENTE_CADASTRADO, ()) {
+                    eprintln!("Evento {EVENTO_PACIENTE_CADASTRADO} não foi emitido: {erro}");
+                }
+            })
+        },
     };
     let rotas = rotas_auto_cadastro(estado).fallback_service(rotas_spa(app.clone()));
     // Escuta a rede local inteira: é assim que o tablet chega (ADR-0003). A
@@ -179,7 +203,10 @@ async fn cadastrar_paciente(
         return StatusCode::UNPROCESSABLE_ENTITY;
     }
     match inserir_paciente(&estado.caminho_banco, &novo) {
-        Ok(()) => StatusCode::CREATED,
+        Ok(()) => {
+            (estado.avisar_paciente_cadastrado)();
+            StatusCode::CREATED
+        }
         Err(erro) if cpf_ja_cadastrado(&erro) => StatusCode::CONFLICT,
         Err(_) => StatusCode::INTERNAL_SERVER_ERROR,
     }
@@ -327,6 +354,7 @@ mod testes {
         let estado = EstadoAutoCadastro {
             caminho_banco,
             diretorio_fotos: pasta.path().join(crate::fotos::DIRETORIO_FOTOS),
+            avisar_paciente_cadastrado: Arc::new(|| {}),
         };
         (pasta, estado)
     }
@@ -357,6 +385,18 @@ mod testes {
             "quandoFoiHospitalizado": null,
             "razaoHospitalizacao": null
         })
+    }
+
+    /// Estado cujo aviso conta quantas vezes o desktop seria avisado.
+    fn estado_com_contagem_de_avisos(
+    ) -> (tempfile::TempDir, EstadoAutoCadastro, Arc<std::sync::atomic::AtomicUsize>) {
+        let (pasta, mut estado) = estado_de_teste();
+        let avisos = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let contador = Arc::clone(&avisos);
+        estado.avisar_paciente_cadastrado = Arc::new(move || {
+            contador.fetch_add(1, Ordering::SeqCst);
+        });
+        (pasta, estado, avisos)
     }
 
     async fn cadastrar(
@@ -435,6 +475,41 @@ mod testes {
             )
             .expect("consultar o paciente original");
         assert_eq!(nome, "Ana Lima", "o cadastro original deve ficar intacto");
+    }
+
+    #[tokio::test]
+    async fn cadastro_gravado_avisa_o_desktop_para_recarregar_a_listagem() {
+        let (_pasta, estado, avisos) = estado_com_contagem_de_avisos();
+
+        let status = cadastrar(&estado, &cadastro_valido()).await;
+
+        assert_eq!(status, StatusCode::CREATED);
+        // É este aviso que vira o evento `paciente-cadastrado` no app
+        // (issue #22): a listagem de Pacientes recarrega ao recebê-lo.
+        assert_eq!(avisos.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn cadastro_recusado_nao_avisa_o_desktop() {
+        let (_pasta, estado, avisos) = estado_com_contagem_de_avisos();
+
+        // CPF inválido: nada foi gravado, nada muda na listagem.
+        let mut invalido = cadastro_valido();
+        invalido["cpf"] = json!("11111111111");
+        assert_eq!(
+            cadastrar(&estado, &invalido).await,
+            StatusCode::UNPROCESSABLE_ENTITY
+        );
+
+        // CPF duplicado: o conflito também não grava nada.
+        assert_eq!(cadastrar(&estado, &cadastro_valido()).await, StatusCode::CREATED);
+        assert_eq!(cadastrar(&estado, &cadastro_valido()).await, StatusCode::CONFLICT);
+
+        assert_eq!(
+            avisos.load(Ordering::SeqCst),
+            1,
+            "só o cadastro gravado deve avisar o desktop"
+        );
     }
 
     #[tokio::test]

--- a/src/db/eventos.ts
+++ b/src/db/eventos.ts
@@ -1,0 +1,13 @@
+import { listen, type UnlistenFn } from "@tauri-apps/api/event";
+
+/**
+ * Evento que o servidor do Auto-cadastro (src-tauri/src/servidor.rs) emite ao
+ * gravar um Paciente vindo do tablet — espelho de EVENTO_PACIENTE_CADASTRADO
+ * no Rust. Só existe no Modo desktop: o webview é quem recebe eventos Tauri.
+ */
+export const EVENTO_PACIENTE_CADASTRADO = "paciente-cadastrado";
+
+/** Reage a cada Auto-cadastro gravado; devolve como parar de escutar. */
+export function aoPacienteCadastrado(reagir: () => void): Promise<UnlistenFn> {
+  return listen(EVENTO_PACIENTE_CADASTRADO, reagir);
+}

--- a/src/layout/layout-app.test.tsx
+++ b/src/layout/layout-app.test.tsx
@@ -7,15 +7,18 @@ import {
   programarComando,
   reiniciarComandosFalsos,
 } from "@/testes/comandos-falsos";
+import { reiniciarEventosFalsos } from "@/testes/eventos-falsos";
 import { encerrarModoDesktop, simularModoDesktop } from "@/testes/modo-desktop";
 
 vi.mock("@tauri-apps/plugin-sql", () => import("@/testes/plugin-sql-vazio"));
 vi.mock("@tauri-apps/api/core", () => import("@/testes/comandos-falsos"));
+vi.mock("@tauri-apps/api/event", () => import("@/testes/eventos-falsos"));
 
 // Estas telas são o Modo desktop: o layout só aparece dentro do webview do app.
 beforeEach(() => {
   simularModoDesktop();
   reiniciarComandosFalsos();
+  reiniciarEventosFalsos();
 });
 afterEach(encerrarModoDesktop);
 

--- a/src/paginas/pacientes.test.tsx
+++ b/src/paginas/pacientes.test.tsx
@@ -1,13 +1,19 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes, useParams } from "react-router";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { EVENTO_PACIENTE_CADASTRADO } from "@/db/eventos";
 import type { DadosPaciente } from "@/dominio/paciente";
 import {
   chamadasDeComando,
   programarComando,
   reiniciarComandosFalsos,
 } from "@/testes/comandos-falsos";
+import {
+  emitirEventoFalso,
+  reiniciarEventosFalsos,
+  totalDeOuvintes,
+} from "@/testes/eventos-falsos";
 import { consultaAberta, linhaDeConsulta } from "@/testes/fixtures-consulta";
 import {
   dadosPacienteValidos,
@@ -20,15 +26,17 @@ import {
 } from "@/testes/plugin-sql-falso";
 import { PaginaPacientes } from "./pacientes";
 
-// Fronteiras do sistema: o banco SQLite atrás do tauri-plugin-sql e o comando
-// Tauri que lê fotos. O caminho página → listarPacientes → drizzle roda de
-// verdade.
+// Fronteiras do sistema: o banco SQLite atrás do tauri-plugin-sql, o comando
+// Tauri que lê fotos e os eventos Tauri que o backend emite. O caminho
+// página → listarPacientes → drizzle roda de verdade.
 vi.mock("@tauri-apps/plugin-sql", () => import("@/testes/plugin-sql-falso"));
 vi.mock("@tauri-apps/api/core", () => import("@/testes/comandos-falsos"));
+vi.mock("@tauri-apps/api/event", () => import("@/testes/eventos-falsos"));
 
 beforeEach(() => {
   reiniciarBancoFalso();
   reiniciarComandosFalsos();
+  reiniciarEventosFalsos();
   proximoId = 1;
   // Só o relógio de parede é falso (idades estáveis); timers continuam reais
   // para não interferir no user-event e nos findBy*.
@@ -363,6 +371,85 @@ test("a listagem é paginada de 10 em 10", async () => {
 
   expect(nomesExibidos()).toHaveLength(10);
   expect(screen.getByText("Página 1 de 2")).toBeInTheDocument();
+});
+
+/** Recarga vinda do banco: Ana já cadastrada e Bia recém-chegada do tablet. */
+function anaEBia() {
+  return [
+    pacienteNaListagem(),
+    pacienteNaListagem({ nomeCompleto: "Bia Souza", cpf: "12345678909" }),
+  ];
+}
+
+test("um Auto-cadastro chegando do tablet recarrega a listagem", async () => {
+  enfileirarSelect([pacienteNaListagem()]);
+  renderizarPagina();
+  await screen.findByText("Ana Lima");
+
+  // O servidor local gravou Bia e avisou; a página relê o banco (issue #22).
+  enfileirarSelect(anaEBia());
+  emitirEventoFalso(EVENTO_PACIENTE_CADASTRADO);
+
+  expect(await screen.findByText("Bia Souza")).toBeInTheDocument();
+  expect(screen.getByText("Ana Lima")).toBeInTheDocument();
+});
+
+test("a recarga preserva a busca digitada", async () => {
+  const terapeuta = userEvent.setup();
+  enfileirarSelect([pacienteNaListagem()]);
+  renderizarPagina();
+  await screen.findByText("Ana Lima");
+
+  await terapeuta.type(
+    screen.getByRole("searchbox", { name: "Buscar por nome" }),
+    "bia",
+  );
+  expect(screen.getByText("Nenhum paciente encontrado")).toBeInTheDocument();
+
+  enfileirarSelect(anaEBia());
+  emitirEventoFalso(EVENTO_PACIENTE_CADASTRADO);
+
+  // A linha nova entra já filtrada pela busca que estava na tela.
+  expect(await screen.findByText("Bia Souza")).toBeInTheDocument();
+  expect(screen.queryByText("Ana Lima")).not.toBeInTheDocument();
+  expect(
+    screen.getByRole("searchbox", { name: "Buscar por nome" }),
+  ).toHaveValue("bia");
+});
+
+test("a recarga preserva a página em exibição", async () => {
+  const terapeuta = userEvent.setup();
+  enfileirarSelect(onzePacientes());
+  renderizarPagina();
+  await screen.findByText("Paciente 01");
+  await terapeuta.click(screen.getByRole("button", { name: "Próxima" }));
+  expect(screen.getByText("Página 2 de 2")).toBeInTheDocument();
+
+  enfileirarSelect([
+    ...onzePacientes(),
+    pacienteNaListagem({ nomeCompleto: "Bia Souza", cpf: "12345678909" }),
+  ]);
+  emitirEventoFalso(EVENTO_PACIENTE_CADASTRADO);
+
+  // Bia entra na primeira página (ordem por nome) e empurra o Paciente 10
+  // para a segunda — que segue em exibição, sem voltar ao início.
+  await waitFor(() => {
+    expect(nomesExibidos()).toEqual(["Paciente 10", "Paciente 11"]);
+  });
+  expect(screen.getByText("Página 2 de 2")).toBeInTheDocument();
+});
+
+test("sair da página para de escutar o Auto-cadastro", async () => {
+  enfileirarSelect([pacienteNaListagem()]);
+  const { unmount } = renderizarPagina();
+  await screen.findByText("Ana Lima");
+  expect(totalDeOuvintes(EVENTO_PACIENTE_CADASTRADO)).toBe(1);
+
+  unmount();
+
+  await vi.waitFor(() => {
+    expect(totalDeOuvintes(EVENTO_PACIENTE_CADASTRADO)).toBe(0);
+  });
 });
 
 test("buscar volta para a primeira página", async () => {

--- a/src/paginas/pacientes.tsx
+++ b/src/paginas/pacientes.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/components/ui/table";
 import { consultasAbertas, criarConsulta } from "@/db/consultas";
 import { saldosDeCreditos } from "@/db/creditos";
+import { aoPacienteCadastrado } from "@/db/eventos";
 import { listarPacientes, type Paciente } from "@/db/pacientes";
 import { calcularIdade, hojeIso } from "@/dominio/idade";
 import {
@@ -58,15 +59,37 @@ export function PaginaPacientes() {
 
   useEffect(() => {
     let ativo = true;
-    Promise.all([listarPacientes(), saldosDeCreditos(), consultasAbertas()])
-      .then(([pacientes, saldos, abertas]) => {
-        if (ativo) setCarga({ estado: "pronto", pacientes, saldos, abertas });
-      })
-      .catch(() => {
-        if (ativo) setCarga({ estado: "erro" });
-      });
+    let geracao = 0;
+    function carregar() {
+      const geracaoDaCarga = ++geracao;
+      const maisRecente = () => ativo && geracaoDaCarga === geracao;
+      Promise.all([listarPacientes(), saldosDeCreditos(), consultasAbertas()])
+        .then(([pacientes, saldos, abertas]) => {
+          if (maisRecente())
+            setCarga({ estado: "pronto", pacientes, saldos, abertas });
+        })
+        .catch(() => {
+          // Recarga de fundo que falha não derruba a tabela já exibida.
+          if (maisRecente())
+            setCarga((atual) =>
+              atual.estado === "pronto" ? atual : { estado: "erro" },
+            );
+        });
+    }
+    // Auto-cadastro chegando do tablet: o servidor local avisa e a listagem
+    // relê o banco — a linha nova aparece sem sair da página (issue #22).
+    // A escuta entra antes da primeira carga para não haver janela de evento
+    // perdido: cadastro gravado antes dela já sai no primeiro SELECT; depois,
+    // dispara a recarga. Cargas concorrentes se resolvem pela geração — só a
+    // mais recente chega à tela.
+    const escuta = aoPacienteCadastrado(carregar).catch(
+      // Sem escuta (falha do IPC), a listagem atualiza ao revisitar a página.
+      () => () => {},
+    );
+    escuta.then(() => carregar());
     return () => {
       ativo = false;
+      escuta.then((pararDeEscutar) => pararDeEscutar());
     };
   }, []);
 

--- a/src/rotas.test.tsx
+++ b/src/rotas.test.tsx
@@ -3,18 +3,21 @@ import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { Rotas } from "@/rotas";
 import { reiniciarComandosFalsos } from "@/testes/comandos-falsos";
+import { reiniciarEventosFalsos } from "@/testes/eventos-falsos";
 import { fetchFalso, reiniciarFetchFalso } from "@/testes/fetch-falso";
 import { encerrarModoDesktop, simularModoDesktop } from "@/testes/modo-desktop";
 import { reiniciarBancoFalso } from "@/testes/plugin-sql-falso";
 
 vi.mock("@tauri-apps/plugin-sql", () => import("@/testes/plugin-sql-falso"));
 vi.mock("@tauri-apps/api/core", () => import("@/testes/comandos-falsos"));
+vi.mock("@tauri-apps/api/event", () => import("@/testes/eventos-falsos"));
 vi.stubGlobal("fetch", fetchFalso);
 
 beforeEach(() => {
   reiniciarFetchFalso();
   reiniciarBancoFalso();
   reiniciarComandosFalsos();
+  reiniciarEventosFalsos();
 });
 
 afterEach(encerrarModoDesktop);

--- a/src/testes/eventos-falsos.ts
+++ b/src/testes/eventos-falsos.ts
@@ -1,0 +1,34 @@
+// Dublê do @tauri-apps/api/event com ouvintes inspecionáveis, para vi.mock:
+//   vi.mock("@tauri-apps/api/event", () => import("@/testes/eventos-falsos"));
+// Guarda os ouvintes registrados e deixa o teste emitir eventos como o
+// backend Rust emitiria. Reiniciar em beforeEach.
+
+type Ouvinte = () => void;
+
+const ouvintes = new Map<string, Set<Ouvinte>>();
+
+export function reiniciarEventosFalsos(): void {
+  ouvintes.clear();
+}
+
+/** Quantos ouvintes o evento tem agora — confere a limpeza no desmontar. */
+export function totalDeOuvintes(evento: string): number {
+  return ouvintes.get(evento)?.size ?? 0;
+}
+
+/** Dispara o evento para os ouvintes, como o backend Rust ao emitir. */
+export function emitirEventoFalso(evento: string): void {
+  for (const ouvinte of ouvintes.get(evento) ?? []) ouvinte();
+}
+
+export async function listen(
+  evento: string,
+  ouvinte: Ouvinte,
+): Promise<() => void> {
+  const conjunto = ouvintes.get(evento) ?? new Set();
+  conjunto.add(ouvinte);
+  ouvintes.set(evento, conjunto);
+  return () => {
+    conjunto.delete(ouvinte);
+  };
+}


### PR DESCRIPTION
## Resumo

Leva à `main` o trabalho da `dev`: a listagem de Pacientes agora se atualiza ao vivo quando um Auto-cadastro chega pelo tablet (#22).

- **Backend**: a rota REST do Auto-cadastro avisa o app ao gravar um Paciente. `EstadoAutoCadastro` ganha o fecho plugável `avisar_paciente_cadastrado`, chamado apenas quando o INSERT é bem-sucedido — recusas (422/409) não avisam. Em produção o fecho emite o evento Tauri `paciente-cadastrado`; nos testes, conta-se os avisos sem subir um app Tauri.
- **Frontend**: nova fronteira `src/db/eventos.ts` (`aoPacienteCadastrado`). A página de Pacientes registra a escuta antes da primeira carga (sem janela de evento perdido), recarrega sem polling e preserva busca, ordenação e página em exibição. Cargas concorrentes se resolvem por token de geração.
- **Docs e testes**: spec 1.2 ganha a regra "Atualização ao vivo"; +2 testes no Rust (62 no total) e +4 no Vitest (297 no total), com dublê novo de `@tauri-apps/api/event`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019z5b4CY4sWTGE9vtvKuetx