### PR TITLE
Campo "Motivo da terapia" no cadastro do Paciente e no cabeçalho da Consulta

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -17,6 +17,10 @@ _Evitar_: cliente, usuário
 **Responsável legal**:
 Adulto que responde por um Paciente menor de 18 anos. Obrigatório para menores; opcional para os demais.
 
+**Motivo da terapia**:
+O que o Paciente relata, no próprio cadastro, como razão de ter procurado terapia. Nasce no cadastro, antes de qualquer Consulta; a Terapeuta pode revisá-lo depois.
+_Evitar_: motivo da consulta (colide com Consulta), queixa, demanda, motivo da busca
+
 **Auto-cadastro**:
 Preenchimento do próprio cadastro pelo Paciente no tablet do consultório. Só cria Pacientes — nunca edita.
 _Evitar_: cadastro remoto, pré-cadastro

--- a/biome.json
+++ b/biome.json
@@ -45,6 +45,16 @@
   },
   "overrides": [
     {
+      "includes": ["src-tauri/icons/**"],
+      "linter": {
+        "rules": {
+          "a11y": {
+            "noSvgWithoutTitle": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["src/components/ui/**", "src/hooks/use-mobile.ts"],
       "linter": {
         "rules": {

--- a/docs/design.md
+++ b/docs/design.md
@@ -167,7 +167,7 @@ Estados obrigatórios: hover, `focus-visible` (anel `ring-3 ring-ring/50`),
 `active` (desce 1px), `disabled` (50% de opacidade, sem ponteiro),
 `aria-invalid`. Ícone sempre antes do rótulo, `size-4`.
 
-### 3.4 Campos (`ui/input.tsx`, `ui/select-nativo.tsx`)
+### 3.4 Campos (`ui/input.tsx`, `ui/textarea.tsx`, `ui/select-nativo.tsx`)
 
 - `h-8`, `bg-glass-fill`, contorno `--input` (3:1 sobre o cartão), hover
   escurece o contorno, foco = contorno `--ring` + anel, erro = contorno e anel
@@ -180,7 +180,12 @@ Estados obrigatórios: hover, `focus-visible` (anel `ring-3 ring-ring/50`),
   `[data-slot="select-nativo"]`); a lista aberta continua nativa. As classes
   do select **não** incluem `read-only:` — `:read-only` casa com todo
   `<select>`.
-- Rótulo `text-sm font-medium`; asterisco vermelho fora do `<label>`.
+- O textarea (texto livre multilinha, como o Motivo da terapia) usa as
+  mesmas classes do input — a única exceção ao `h-8`: `min-h-28`, esticável
+  na vertical (`resize-y`), `py-2 leading-relaxed`.
+- Rótulo `text-sm font-medium`; asterisco vermelho fora do `<label>`. Dica
+  `text-xs text-muted-foreground` abaixo do campo, ligada ao controle por
+  `aria-describedby` junto com o erro.
 
 ### 3.5 Tabelas (`ui/table.tsx`)
 

--- a/docs/especificacao.md
+++ b/docs/especificacao.md
@@ -48,6 +48,7 @@ Escopo cortado de propósito — não são lacunas:
 | Telefone 1 | texto | Sim | Para paciente menor de idade, é o telefone do Responsável legal (convenção — sem campo próprio) |
 | Telefone 2 | texto | Não | — |
 | Email | email | Não | — |
+| Motivo da terapia | texto multilinha | Sim | O que o paciente relata, com as próprias palavras, como razão de ter procurado terapia — texto livre, sem limite nem lista fechada. Nasce no cadastro (pelo próprio paciente no Auto-cadastro, ou pela terapeuta no desktop) e pode ser revisado em "Editar Paciente" |
 | Já fez terapia? | enum | Sim | Sim, Não |
 | Quando fez terapia? | texto | Condicional | Obrigatório se "Já fez terapia?" = Sim |
 | Toma algum medicamento? | enum | Sim | Sim, Não |
@@ -121,6 +122,12 @@ Página responsiva para cadastro e edição de pacientes.
 
 - Os dois campos de CPF (do paciente e do Responsável legal) aplicam a máscara **000.000.000-00 enquanto o usuário digita**, ignorando o que não é dígito e parando no 11º. No banco o CPF é gravado só com os dígitos.
 
+**Motivo da terapia (nos dois modos):**
+
+- Seção própria **"Motivo da terapia"**, entre "Contato" e "Histórico clínico", com um único campo de texto multilinha ocupando a largura total — nenhum grupo existente muda de lugar.
+- Obrigatório nos dois modos; em branco, o erro padrão "Campo obrigatório". Um paciente cadastrado antes de o campo existir abre a edição com ele vazio e a terapeuta precisa preenchê-lo para salvar.
+- No Modo tablet, dica abaixo do campo: *"Conte com suas palavras. Não precisa ser detalhado, a terapeuta vai conversar sobre isso com você."* No desktop, sem dica.
+
 **Modo tablet (Auto-cadastro pelo paciente):**
 
 - Ao acessar o sistema via navegador na rede local (iPad ou qualquer outro dispositivo), o usuário é redirecionado automaticamente para o formulário de novo paciente.
@@ -188,6 +195,7 @@ Acionada pelo botão "Nova Consulta" na listagem de pacientes.
 - Idade do paciente
 - Timer em tempo real
 - Ações contextuais conforme o status (ver tabela de editabilidade): "Finalizar Consulta", "Efetuar Pagamento", "Desfazer Pagamento", "Cancelar Consulta"
+- **Motivo da terapia** (seção 1.1), numa linha própria abaixo de foto/nome/idade e das ações, com o texto completo — sem truncar nem "ver mais"; texto longo empurra Conteúdo e Notas para baixo. Somente leitura: editar é em "Editar Paciente". Paciente sem motivo registrado: *"Motivo da terapia não informado"*, discreto, com link para a edição do cadastro.
 
 **Timer (duração fixa: 1 hora, não configurável no v1):**
 

--- a/src-tauri/migrations/0004_motivo-terapia-paciente.sql
+++ b/src-tauri/migrations/0004_motivo-terapia-paciente.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `pacientes` ADD `motivo_terapia` text;

--- a/src-tauri/migrations/meta/0004_snapshot.json
+++ b/src-tauri/migrations/meta/0004_snapshot.json
@@ -1,0 +1,425 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "445c4e6f-6918-4b43-8506-2ce9321dd7d7",
+  "prevId": "35bd0621-c555-4367-ac9e-73cee92726a0",
+  "tables": {
+    "consultas": {
+      "name": "consultas",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "paciente_id": {
+          "name": "paciente_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "iniciado_em": {
+          "name": "iniciado_em",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finalizado_em": {
+          "name": "finalizado_em",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pago_em": {
+          "name": "pago_em",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'Aberta'"
+        },
+        "conteudo": {
+          "name": "conteudo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "notas": {
+          "name": "notas",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "preco_centavos": {
+          "name": "preco_centavos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pago": {
+          "name": "pago",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "origem_pagamento": {
+          "name": "origem_pagamento",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "consultas_paciente_aberta_unica": {
+          "name": "consultas_paciente_aberta_unica",
+          "columns": [
+            "paciente_id"
+          ],
+          "isUnique": true,
+          "where": "\"consultas\".\"status\" = 'Aberta'"
+        }
+      },
+      "foreignKeys": {
+        "consultas_paciente_id_pacientes_id_fk": {
+          "name": "consultas_paciente_id_pacientes_id_fk",
+          "tableFrom": "consultas",
+          "tableTo": "pacientes",
+          "columnsFrom": [
+            "paciente_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "movimentos_credito": {
+      "name": "movimentos_credito",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "paciente_id": {
+          "name": "paciente_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tipo": {
+          "name": "tipo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quantidade": {
+          "name": "quantidade",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ocorrido_em": {
+          "name": "ocorrido_em",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consulta_id": {
+          "name": "consulta_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "valor_unitario_centavos": {
+          "name": "valor_unitario_centavos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motivo": {
+          "name": "motivo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "movimentos_credito_paciente_id_pacientes_id_fk": {
+          "name": "movimentos_credito_paciente_id_pacientes_id_fk",
+          "tableFrom": "movimentos_credito",
+          "tableTo": "pacientes",
+          "columnsFrom": [
+            "paciente_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "movimentos_credito_consulta_id_consultas_id_fk": {
+          "name": "movimentos_credito_consulta_id_consultas_id_fk",
+          "tableFrom": "movimentos_credito",
+          "tableTo": "consultas",
+          "columnsFrom": [
+            "consulta_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "pacientes": {
+      "name": "pacientes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "nome_completo": {
+          "name": "nome_completo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "foto": {
+          "name": "foto",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "data_nascimento": {
+          "name": "data_nascimento",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "genero": {
+          "name": "genero",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cpf": {
+          "name": "cpf",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rg": {
+          "name": "rg",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "religiao": {
+          "name": "religiao",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "responsavel_legal": {
+          "name": "responsavel_legal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email_responsavel_legal": {
+          "name": "email_responsavel_legal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cpf_responsavel_legal": {
+          "name": "cpf_responsavel_legal",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "telefone_1": {
+          "name": "telefone_1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "telefone_2": {
+          "name": "telefone_2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "motivo_terapia": {
+          "name": "motivo_terapia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ja_fez_terapia": {
+          "name": "ja_fez_terapia",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quando_fez_terapia": {
+          "name": "quando_fez_terapia",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "toma_medicamento": {
+          "name": "toma_medicamento",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "toma_medicamento_desde_quando": {
+          "name": "toma_medicamento_desde_quando",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "nomes_medicamentos": {
+          "name": "nomes_medicamentos",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ja_foi_hospitalizado": {
+          "name": "ja_foi_hospitalizado",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "quando_foi_hospitalizado": {
+          "name": "quando_foi_hospitalizado",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "razao_hospitalizacao": {
+          "name": "razao_hospitalizacao",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "valor_consulta_centavos": {
+          "name": "valor_consulta_centavos",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "periodicidade": {
+          "name": "periodicidade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dia_semana_consulta": {
+          "name": "dia_semana_consulta",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "pacientes_cpf_unique": {
+          "name": "pacientes_cpf_unique",
+          "columns": [
+            "cpf"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/src-tauri/migrations/meta/_journal.json
+++ b/src-tauri/migrations/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1786281411434,
       "tag": "0003_nova-consulta-e-movimentos-de-credito",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1788616863568,
+      "tag": "0004_motivo-terapia-paciente",
+      "breakpoints": true
     }
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -45,6 +45,12 @@ pub fn migracoes() -> Vec<Migration> {
             sql: include_str!("../migrations/0003_nova-consulta-e-movimentos-de-credito.sql"),
             kind: MigrationKind::Up,
         },
+        Migration {
+            version: 5,
+            description: "motivo_terapia_paciente",
+            sql: include_str!("../migrations/0004_motivo-terapia-paciente.sql"),
+            kind: MigrationKind::Up,
+        },
     ]
 }
 
@@ -313,6 +319,25 @@ mod testes {
             .expect("consultar a foto do paciente");
 
         assert_eq!(foto.as_deref(), Some("foto-1.jpg"));
+    }
+
+    #[test]
+    fn motivo_da_terapia_nasce_nulo_para_cadastros_anteriores_ao_campo() {
+        let conexao = banco_migrado();
+
+        // Um Paciente gravado antes da migração 0004 não tem o campo: a coluna
+        // precisa aceitar a ausência para a migração não perder dados.
+        inserir_paciente(&conexao, "Ana Lima", "52998224725")
+            .expect("inserir paciente sem Motivo da terapia");
+
+        let motivo: Option<String> = conexao
+            .query_row(
+                "SELECT motivo_terapia FROM pacientes WHERE cpf = '52998224725'",
+                [],
+                |linha| linha.get(0),
+            )
+            .expect("consultar o Motivo da terapia");
+        assert_eq!(motivo, None);
     }
 
     /// Insere uma Consulta Aberta só com os campos sem valor padrão (spec 2.1).

--- a/src-tauri/src/servidor.rs
+++ b/src-tauri/src/servidor.rs
@@ -78,6 +78,9 @@ pub struct NovoPacienteAutoCadastro {
     telefone_1: String,
     telefone_2: Option<String>,
     email: Option<String>,
+    /// Motivo da terapia (CONTEXT.md), nas palavras do Paciente. Obrigatório
+    /// (issue #30): `String`, não `Option`, para o serde recusar a ausência.
+    motivo_terapia: String,
     ja_fez_terapia: bool,
     quando_fez_terapia: Option<String>,
     toma_medicamento: bool,
@@ -223,6 +226,7 @@ fn validar(novo: &NovoPacienteAutoCadastro) -> Result<(), String> {
         ("genero", &novo.genero),
         ("religiao", &novo.religiao),
         ("telefone1", &novo.telefone_1),
+        ("motivoTerapia", &novo.motivo_terapia),
     ];
     for (campo, valor) in obrigatorios {
         if valor.trim().is_empty() {
@@ -295,13 +299,13 @@ fn inserir_paciente(
         "INSERT INTO pacientes (
             nome_completo, foto, data_nascimento, genero, cpf, rg, religiao,
             responsavel_legal, email_responsavel_legal, cpf_responsavel_legal,
-            telefone_1, telefone_2, email,
+            telefone_1, telefone_2, email, motivo_terapia,
             ja_fez_terapia, quando_fez_terapia,
             toma_medicamento, toma_medicamento_desde_quando, nomes_medicamentos,
             ja_foi_hospitalizado, quando_foi_hospitalizado, razao_hospitalizacao,
             valor_consulta_centavos
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13,
-                  ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22)",
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14,
+                  ?15, ?16, ?17, ?18, ?19, ?20, ?21, ?22, ?23)",
         rusqlite::params![
             novo.nome_completo,
             novo.foto,
@@ -316,6 +320,7 @@ fn inserir_paciente(
             novo.telefone_1,
             novo.telefone_2,
             novo.email,
+            novo.motivo_terapia.trim(),
             novo.ja_fez_terapia,
             novo.quando_fez_terapia,
             novo.toma_medicamento,
@@ -376,6 +381,7 @@ mod testes {
             "telefone1": "(11) 91234-5678",
             "telefone2": null,
             "email": null,
+            "motivoTerapia": "Ansiedade no trabalho, crises de choro",
             "jaFezTerapia": false,
             "quandoFezTerapia": null,
             "tomaMedicamento": false,
@@ -435,22 +441,38 @@ mod testes {
         // aplicado automaticamente; campos ocultos ficam vazios).
         let conexao = rusqlite::Connection::open(&estado.caminho_banco)
             .expect("abrir o SQLite de teste");
-        let (nome, valor, periodicidade, dia): (String, i64, Option<String>, Option<String>) =
-            conexao
-                .query_row(
-                    "SELECT nome_completo, valor_consulta_centavos,
-                            periodicidade, dia_semana_consulta
-                     FROM pacientes WHERE cpf = '52998224725'",
-                    [],
-                    |linha| {
-                        Ok((linha.get(0)?, linha.get(1)?, linha.get(2)?, linha.get(3)?))
-                    },
-                )
-                .expect("consultar o paciente criado");
+        let (nome, valor, periodicidade, dia, motivo): (
+            String,
+            i64,
+            Option<String>,
+            Option<String>,
+            Option<String>,
+        ) = conexao
+            .query_row(
+                "SELECT nome_completo, valor_consulta_centavos,
+                        periodicidade, dia_semana_consulta, motivo_terapia
+                 FROM pacientes WHERE cpf = '52998224725'",
+                [],
+                |linha| {
+                    Ok((
+                        linha.get(0)?,
+                        linha.get(1)?,
+                        linha.get(2)?,
+                        linha.get(3)?,
+                        linha.get(4)?,
+                    ))
+                },
+            )
+            .expect("consultar o paciente criado");
         assert_eq!(nome, "Ana Lima");
         assert_eq!(valor, 25000);
         assert_eq!(periodicidade, None);
         assert_eq!(dia, None);
+        // O Motivo da terapia é o que o Paciente contou no tablet (issue #30).
+        assert_eq!(
+            motivo.as_deref(),
+            Some("Ansiedade no trabalho, crises de choro")
+        );
     }
 
     #[tokio::test]
@@ -533,6 +555,7 @@ mod testes {
             "genero",
             "religiao",
             "telefone1",
+            "motivoTerapia",
         ] {
             let mut cadastro = cadastro_valido();
             cadastro[campo] = json!("   ");
@@ -545,6 +568,23 @@ mod testes {
                 "{campo} em branco deveria ser recusado"
             );
         }
+        assert_eq!(pacientes_gravados(&estado), 0);
+    }
+
+    #[tokio::test]
+    async fn cadastro_sem_o_motivo_da_terapia_e_recusado_sem_gravar() {
+        let (_pasta, estado) = estado_de_teste();
+        // Um formulário anterior ao campo (ou fora da SPA) nem manda a chave:
+        // o Motivo da terapia é obrigatório também nesta fronteira.
+        let mut cadastro = cadastro_valido();
+        cadastro
+            .as_object_mut()
+            .expect("cadastro é um objeto JSON")
+            .remove("motivoTerapia");
+
+        let status = cadastrar(&estado, &cadastro).await;
+
+        assert_eq!(status, StatusCode::UNPROCESSABLE_ENTITY);
         assert_eq!(pacientes_gravados(&estado), 0);
     }
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -34,4 +34,4 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
   );
 }
 
-export { classesDoCampo, Input };
+export { classesDeSomenteLeitura, classesDoCampo, Input };

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,26 @@
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { classesDeSomenteLeitura, classesDoCampo } from "./input";
+
+/*
+ * Campo multilinha sobre vidro (docs/design.md 3.4): as classes do Input,
+ * trocando a altura fixa de uma linha por uma altura mínima que a pessoa
+ * pode esticar. Somente leitura se comporta como no Input.
+ */
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        classesDoCampo,
+        classesDeSomenteLeitura,
+        "h-auto min-h-28 resize-y py-2 leading-relaxed",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Textarea };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -38,6 +38,9 @@ export const pacientes = sqliteTable("pacientes", {
   telefone1: text("telefone_1").notNull(),
   telefone2: text("telefone_2"),
   email: text("email"),
+  // Nula só para quem foi cadastrado antes do campo existir (migração 0004);
+  // a obrigatoriedade é do domínio, como nos condicionais clínicos.
+  motivoTerapia: text("motivo_terapia"),
   jaFezTerapia: integer("ja_fez_terapia", { mode: "boolean" }).notNull(),
   quandoFezTerapia: text("quando_fez_terapia"),
   tomaMedicamento: integer("toma_medicamento", { mode: "boolean" }).notNull(),

--- a/src/dominio/paciente.test.ts
+++ b/src/dominio/paciente.test.ts
@@ -27,6 +27,7 @@ function formularioValido(
     telefone1: "(11) 91234-5678",
     telefone2: "",
     email: "ana@exemplo.com",
+    motivoTerapia: "Ansiedade no trabalho, crises de choro",
     jaFezTerapia: "Não",
     quandoFezTerapia: "",
     tomaMedicamento: "Não",
@@ -55,6 +56,7 @@ test("campos obrigatórios vazios são apontados", () => {
       cpf: "",
       religiao: "",
       telefone1: "",
+      motivoTerapia: "   ",
       jaFezTerapia: "",
       tomaMedicamento: "",
       jaFoiHospitalizado: "",
@@ -70,6 +72,7 @@ test("campos obrigatórios vazios são apontados", () => {
     "cpf",
     "religiao",
     "telefone1",
+    "motivoTerapia",
     "jaFezTerapia",
     "tomaMedicamento",
     "jaFoiHospitalizado",
@@ -235,6 +238,7 @@ test("converte o formulário validado no registro do banco", () => {
       quandoFezTerapia: "Entre 2018 e 2020",
       rg: "",
       telefone2: "",
+      motivoTerapia: "  Ansiedade no trabalho, crises de choro  ",
     }),
     "foto-1.jpg",
   );
@@ -253,6 +257,7 @@ test("converte o formulário validado no registro do banco", () => {
     telefone1: "(11) 91234-5678",
     telefone2: null,
     email: "ana@exemplo.com",
+    motivoTerapia: "Ansiedade no trabalho, crises de choro",
     jaFezTerapia: true,
     quandoFezTerapia: "Entre 2018 e 2020",
     tomaMedicamento: false,
@@ -341,4 +346,19 @@ test("registro do banco volta ao formulário para edição", () => {
   const volta = dadosParaFormulario(formularioParaDados(ida, "foto-1.jpg"));
 
   expect(volta).toEqual(ida);
+});
+
+test("Paciente gravado antes do Motivo da terapia abre com o campo vazio", () => {
+  const antigo = {
+    ...formularioParaDados(formularioValido(), null),
+    motivoTerapia: null,
+  };
+
+  const formulario = dadosParaFormulario(antigo);
+
+  expect(formulario.motivoTerapia).toBe("");
+  // Vazio é vazio: a Terapeuta precisa preencher para salvar.
+  expect(validarFormularioPaciente(formulario, HOJE).motivoTerapia).toBe(
+    "Campo obrigatório",
+  );
 });

--- a/src/dominio/paciente.ts
+++ b/src/dominio/paciente.ts
@@ -70,6 +70,8 @@ export interface FormularioPaciente {
   telefone1: string;
   telefone2: string;
   email: string;
+  /** Motivo da terapia (CONTEXT.md): nas palavras do Paciente, texto livre. */
+  motivoTerapia: string;
   jaFezTerapia: string;
   quandoFezTerapia: string;
   tomaMedicamento: string;
@@ -97,6 +99,7 @@ export const FORMULARIO_PACIENTE_VAZIO: FormularioPaciente = {
   telefone1: "",
   telefone2: "",
   email: "",
+  motivoTerapia: "",
   jaFezTerapia: "",
   quandoFezTerapia: "",
   tomaMedicamento: "",
@@ -162,6 +165,7 @@ const CAMPOS_SEMPRE_OBRIGATORIOS = [
   "cpf",
   "religiao",
   "telefone1",
+  "motivoTerapia",
   "jaFezTerapia",
   "tomaMedicamento",
   "jaFoiHospitalizado",
@@ -269,6 +273,11 @@ export interface DadosPaciente {
   telefone1: string;
   telefone2: string | null;
   email: string | null;
+  /**
+   * Obrigatório pelo domínio daqui para a frente; null só em Pacientes
+   * gravados antes de o campo existir (coluna nasceu nula na migração).
+   */
+  motivoTerapia: string | null;
   jaFezTerapia: boolean;
   quandoFezTerapia: string | null;
   tomaMedicamento: boolean;
@@ -313,6 +322,7 @@ export function formularioParaDados(
     telefone1: dados.telefone1.trim(),
     telefone2: texto(dados.telefone2),
     email: texto(dados.email),
+    motivoTerapia: dados.motivoTerapia.trim(),
     jaFezTerapia: dados.jaFezTerapia === "Sim",
     quandoFezTerapia: dependente(dados.jaFezTerapia, dados.quandoFezTerapia),
     tomaMedicamento: dados.tomaMedicamento === "Sim",
@@ -357,6 +367,7 @@ export function dadosParaFormulario(dados: DadosPaciente): FormularioPaciente {
     telefone1: dados.telefone1,
     telefone2: dados.telefone2 ?? "",
     email: dados.email ?? "",
+    motivoTerapia: dados.motivoTerapia ?? "",
     jaFezTerapia: simNao(dados.jaFezTerapia),
     quandoFezTerapia: dados.quandoFezTerapia ?? "",
     tomaMedicamento: simNao(dados.tomaMedicamento),

--- a/src/paginas/auto-cadastro.test.tsx
+++ b/src/paginas/auto-cadastro.test.tsx
@@ -77,6 +77,10 @@ async function preencherCamposObrigatorios(paciente: UserEvent) {
     "Sem religião",
   );
   await paciente.type(screen.getByLabelText("Telefone 1"), "(11) 91234-5678");
+  await paciente.type(
+    screen.getByLabelText("Motivo da terapia"),
+    "Ansiedade no trabalho",
+  );
   await paciente.selectOptions(screen.getByLabelText("Já fez terapia?"), "Não");
   await paciente.selectOptions(
     screen.getByLabelText("Toma algum medicamento?"),
@@ -105,6 +109,7 @@ test("cadastro enviado vai à rota REST, confirma e volta em branco para o próx
   const corpo = JSON.parse(String(requisicoesHttp[0].corpo));
   expect(corpo.nomeCompleto).toBe("Ana Lima");
   expect(corpo.cpf).toBe("52998224725");
+  expect(corpo.motivoTerapia).toBe("Ansiedade no trabalho");
   expect(chamadas).toHaveLength(0);
   expect(chamadasDeComando).toHaveLength(0);
 
@@ -130,6 +135,23 @@ test("CPF já cadastrado orienta a chamar a terapeuta e preserva o que foi digit
   // Nada foi criado nem alterado; o formulário continua com os dados.
   expect(screen.queryByText("Cadastro recebido!")).not.toBeInTheDocument();
   expect(screen.getByLabelText("Nome completo")).toHaveValue("Ana Lima");
+});
+
+test("o Motivo da terapia é obrigatório no tablet e traz a dica para o Paciente", async () => {
+  const paciente = userEvent.setup();
+  renderizarAutoCadastro();
+
+  const motivo = screen.getByLabelText("Motivo da terapia");
+  expect(motivo).toBeRequired();
+  expect(motivo).toHaveAccessibleDescription(
+    "Conte com suas palavras. Não precisa ser detalhado, a terapeuta vai conversar sobre isso com você.",
+  );
+
+  await paciente.click(enviar());
+
+  expect(motivo).toBeInvalid();
+  expect(motivo).toHaveAccessibleDescription(/Campo obrigatório/);
+  expect(requisicoesHttp).toHaveLength(0);
 });
 
 test("as regras reativas valem no navegador: menor de 18 exige o Responsável legal", async () => {

--- a/src/paginas/consulta.test.tsx
+++ b/src/paginas/consulta.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import type { Consulta } from "@/db/consultas";
+import type { DadosPaciente } from "@/dominio/paciente";
 import {
   capturaEstaAtiva,
   emitirBloco,
@@ -66,7 +67,10 @@ afterEach(() => {
 });
 
 /** Programa a carga da página: a consulta 3 do paciente 7 (Ana Lima). */
-function carregarConsulta(ajustes: Partial<Consulta> = {}) {
+function carregarConsulta(
+  ajustes: Partial<Consulta> = {},
+  paciente: Partial<DadosPaciente> = {},
+) {
   enfileirarSelect([
     linhaDeConsulta(
       consultaAberta({
@@ -77,7 +81,9 @@ function carregarConsulta(ajustes: Partial<Consulta> = {}) {
       }),
     ),
   ]);
-  enfileirarSelect([linhaDePaciente({ id: 7, ...dadosPacienteValidos() })]);
+  enfileirarSelect([
+    linhaDePaciente({ id: 7, ...dadosPacienteValidos(paciente) }),
+  ]);
 }
 
 async function renderizarPagina() {
@@ -90,6 +96,15 @@ async function renderizarPagina() {
   );
   await act(async () => {});
   return tela;
+}
+
+/** O cartão do cabeçalho da Consulta (spec 2.3): o que envolve o nome do Paciente. */
+function cabecalhoDaConsulta(): HTMLElement {
+  const cabecalho = screen
+    .getByRole("heading", { name: "Ana Lima" })
+    .closest("header");
+  if (cabecalho === null) throw new Error("cabeçalho da Consulta não achado");
+  return cabecalho;
 }
 
 /** user-event dirigindo os timers falsos do teste. */
@@ -118,6 +133,37 @@ test("o cabeçalho traz nome, idade e timer verde; Conteúdo e Notas vêm carreg
   expect(
     screen.getByRole("button", { name: "Finalizar Consulta" }),
   ).toBeInTheDocument();
+});
+
+test("o cabeçalho mostra o Motivo da terapia completo, só para leitura", async () => {
+  const motivo =
+    "Ansiedade no trabalho, crises de choro e dificuldade para dormir desde que mudei de cargo. Quero entender o que está acontecendo comigo antes que afete minha família.";
+  carregarConsulta({}, { motivoTerapia: motivo });
+  await renderizarPagina();
+
+  const cabecalho = cabecalhoDaConsulta();
+  expect(within(cabecalho).getByText("Motivo da terapia")).toBeInTheDocument();
+  // Texto inteiro, sem truncar nem "ver mais": é leitura de referência.
+  expect(within(cabecalho).getByText(motivo)).toBeInTheDocument();
+  expect(
+    within(cabecalho).queryByRole("textbox", { name: "Motivo da terapia" }),
+  ).not.toBeInTheDocument();
+  expect(
+    within(cabecalho).queryByRole("link", { name: /Editar Paciente/ }),
+  ).not.toBeInTheDocument();
+});
+
+test("Paciente sem Motivo da terapia registrado: o cabeçalho avisa e leva à edição do cadastro", async () => {
+  carregarConsulta({}, { motivoTerapia: null });
+  await renderizarPagina();
+
+  const cabecalho = cabecalhoDaConsulta();
+  expect(
+    within(cabecalho).getByText("Motivo da terapia não informado"),
+  ).toBeInTheDocument();
+  expect(
+    within(cabecalho).getByRole("link", { name: "Editar Paciente" }),
+  ).toHaveAttribute("href", "/pacientes/7/editar");
 });
 
 test("as Notas re-renderizam fielmente o HTML salvo", async () => {

--- a/src/paginas/consulta.tsx
+++ b/src/paginas/consulta.tsx
@@ -1,6 +1,6 @@
 import { Mic } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { useParams } from "react-router";
+import { Link, useParams } from "react-router";
 import { AvisoErro } from "@/components/aviso";
 import { BotaoMicrofone } from "@/components/botao-microfone";
 import { EditorNotas } from "@/components/editor-notas";
@@ -179,6 +179,7 @@ export function PaginaConsulta() {
             <Button onClick={finalizar}>Finalizar Consulta</Button>
           )}
         </div>
+        <MotivoDaTerapia paciente={paciente} />
       </header>
 
       {erroDaAcao !== null && <AvisoErro>{erroDaAcao}</AvisoErro>}
@@ -200,6 +201,38 @@ export function PaginaConsulta() {
         />
       </div>
     </section>
+  );
+}
+
+/**
+ * Motivo da terapia no cabeçalho (spec 2.3): leitura de referência durante o
+ * atendimento — texto completo, sem truncar; editar é em "Editar Paciente".
+ * Paciente cadastrado antes do campo existir (issue #30) não tem motivo: o
+ * aviso leva direto ao cadastro, onde o campo passou a ser obrigatório.
+ */
+function MotivoDaTerapia({ paciente }: { paciente: Paciente }) {
+  const motivo = paciente.motivoTerapia?.trim() ?? "";
+  return (
+    <div className="flex basis-full flex-col gap-1 border-t border-border/60 pt-4">
+      {motivo === "" ? (
+        <p className="flex flex-wrap gap-x-2 text-sm text-muted-foreground">
+          <span>Motivo da terapia não informado</span>
+          <Link
+            to={`/pacientes/${paciente.id}/editar`}
+            className="underline underline-offset-4 hover:text-foreground"
+          >
+            Editar Paciente
+          </Link>
+        </p>
+      ) : (
+        <>
+          <p className="text-sm font-semibold">Motivo da terapia</p>
+          <p className="whitespace-pre-line text-sm leading-relaxed">
+            {motivo}
+          </p>
+        </>
+      )}
+    </div>
   );
 }
 

--- a/src/paginas/paciente-formulario.test.tsx
+++ b/src/paginas/paciente-formulario.test.tsx
@@ -62,6 +62,10 @@ async function preencherCamposObrigatorios(terapeuta: UserEvent) {
     "Sem religião",
   );
   await terapeuta.type(screen.getByLabelText("Telefone 1"), "(11) 91234-5678");
+  await terapeuta.type(
+    screen.getByLabelText("Motivo da terapia"),
+    "Ansiedade no trabalho",
+  );
   await terapeuta.selectOptions(
     screen.getByLabelText("Já fez terapia?"),
     "Não",
@@ -78,6 +82,9 @@ async function preencherCamposObrigatorios(terapeuta: UserEvent) {
 
 const salvar = () => screen.getByRole("button", { name: "Salvar" });
 
+const DICA_DO_TABLET =
+  "Conte com suas palavras. Não precisa ser detalhado, a terapeuta vai conversar sobre isso com você.";
+
 const ultima = <T,>(itens: T[]): T | undefined => itens[itens.length - 1];
 
 test("novo cadastro nasce com o Valor da consulta pré-preenchido e editável", () => {
@@ -89,6 +96,28 @@ test("novo cadastro nasce com o Valor da consulta pré-preenchido e editável", 
   const valor = screen.getByLabelText("Valor da consulta (R$)");
   expect(valor).toHaveValue("250,00");
   expect(valor).toBeEnabled();
+});
+
+test("Motivo da terapia tem seção própria entre Contato e Histórico clínico, obrigatória e sem dica no desktop", () => {
+  renderizarFormulario("/pacientes/novo");
+
+  expect(
+    screen
+      .getAllByRole("heading", { level: 2 })
+      .map((titulo) => titulo.textContent),
+  ).toEqual([
+    "Dados pessoais",
+    "Responsável legal",
+    "Contato",
+    "Motivo da terapia",
+    "Histórico clínico",
+    "Consulta",
+  ]);
+  const motivo = screen.getByLabelText("Motivo da terapia");
+  // Texto livre multilinha, nas palavras do Paciente — nunca uma lista.
+  expect(motivo.tagName).toBe("TEXTAREA");
+  expect(motivo).toBeRequired();
+  expect(screen.queryByText(DICA_DO_TABLET)).not.toBeInTheDocument();
 });
 
 test("menor de 18 anos passa a exigir os três campos do Responsável legal imediatamente", () => {
@@ -315,7 +344,43 @@ test("cadastro válido persiste o paciente e volta à listagem", async () => {
   expect(insercao.sql).toMatch(/insert into "pacientes"/i);
   expect(insercao.valores).toContain("Ana Lima");
   expect(insercao.valores).toContain("52998224725");
+  expect(insercao.valores).toContain("Ansiedade no trabalho");
   expect(insercao.valores).toContain(25000);
+});
+
+test("Paciente cadastrado antes do Motivo da terapia abre com o campo vazio e só salva depois de preenchê-lo", async () => {
+  const terapeuta = userEvent.setup();
+  enfileirarSelect([
+    linhaDePaciente({
+      id: 7,
+      ...dadosPacienteValidos({ motivoTerapia: null }),
+    }),
+  ]);
+  renderizarFormulario("/pacientes/7/editar");
+
+  expect(
+    await screen.findByRole("heading", { name: "Editar Paciente" }),
+  ).toBeInTheDocument();
+  expect(screen.getByLabelText("Motivo da terapia")).toHaveValue("");
+
+  await terapeuta.click(salvar());
+
+  expect(await screen.findByText("Campo obrigatório")).toBeInTheDocument();
+  expect(screen.getByLabelText("Motivo da terapia")).toBeInvalid();
+  // Só a carga do paciente; nenhuma gravação.
+  expect(chamadas).toHaveLength(1);
+
+  await terapeuta.type(
+    screen.getByLabelText("Motivo da terapia"),
+    "Luto recente",
+  );
+  enfileirarSelect([{ total: 0 }]);
+  await terapeuta.click(salvar());
+
+  expect(await screen.findByText("Listagem de pacientes")).toBeInTheDocument();
+  const atualizacao = ultima(chamadas);
+  expect(atualizacao?.sql).toMatch(/update "pacientes" set/i);
+  expect(atualizacao?.valores).toContain("Luto recente");
 });
 
 test("edição carrega o paciente, mostra o CPF com máscara e salva a atualização", async () => {

--- a/src/paginas/paciente-formulario.tsx
+++ b/src/paginas/paciente-formulario.tsx
@@ -7,6 +7,7 @@ import { FotoPaciente } from "@/components/foto-paciente";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { SelectNativo } from "@/components/ui/select-nativo";
+import { Textarea } from "@/components/ui/textarea";
 import {
   criarPacienteAutoCadastro,
   salvarFotoAutoCadastro,
@@ -407,6 +408,26 @@ export function PaginaFormularioPaciente({
           {campoTexto("email", "Email", { tipo: "email" })}
         </SecaoFormulario>
 
+        {/* O Motivo da terapia (CONTEXT.md) nasce no cadastro, nas palavras do
+            Paciente: texto livre, sem lista fechada. Seção própria para não
+            reposicionar nenhum grupo existente (spec 1.3). */}
+        <SecaoFormulario titulo="Motivo da terapia">
+          <CampoTextoMultilinha
+            id="motivoTerapia"
+            rotulo="Motivo da terapia"
+            valor={formulario.motivoTerapia}
+            aoAlterar={alterar("motivoTerapia")}
+            erro={erros.motivoTerapia}
+            obrigatorio
+            // No tablet quem escreve é o Paciente; a Terapeuta não precisa da dica.
+            dica={
+              tablet
+                ? "Conte com suas palavras. Não precisa ser detalhado, a terapeuta vai conversar sobre isso com você."
+                : undefined
+            }
+          />
+        </SecaoFormulario>
+
         {/* Cada pergunta clínica abre um grupo com os próprios dependentes:
             todos ficam sempre na tela, só o somente-leitura muda. Assim
             nenhuma resposta reposiciona os campos das outras perguntas. */}
@@ -537,45 +558,41 @@ function GrupoCampos({ children }: { children: React.ReactNode }) {
   );
 }
 
-interface PropsCampoTexto {
+/** O que todo campo do formulário tem em volta do controle. */
+interface PropsEnvelopeDeCampo {
   id: string;
   rotulo: string;
-  valor: string;
-  aoAlterar: (valor: string) => void;
   obrigatorio?: boolean;
   erro?: string;
   dica?: string;
+  /** Ocupa a linha inteira da grade, em vez de meia. */
+  larguraTotal?: boolean;
+}
+
+interface PropsCampoTexto extends PropsEnvelopeDeCampo {
+  valor: string;
+  aoAlterar: (valor: string) => void;
   tipo?: "text" | "date" | "email";
   /** Campo visível mas não editável — a resposta de que ele depende não é "Sim". */
   somenteLeitura?: boolean;
   /** Reescreve o que foi digitado antes de guardar (ex.: máscara de CPF). */
   mascara?: (valor: string) => string;
   modoEntrada?: React.ComponentProps<"input">["inputMode"];
-  /** Ocupa a linha inteira da grade, em vez de meia. */
-  larguraTotal?: boolean;
 }
 
 function CampoTexto({
-  id,
-  rotulo,
   valor,
   aoAlterar,
-  obrigatorio = false,
-  erro,
-  dica,
   tipo = "text",
   somenteLeitura = false,
   mascara,
   modoEntrada,
-  larguraTotal = false,
+  ...envelope
 }: PropsCampoTexto) {
   return (
-    <div
-      className={cn("flex flex-col gap-1.5", larguraTotal && "md:col-span-2")}
-    >
-      <RotuloCampo para={id} obrigatorio={obrigatorio} texto={rotulo} />
+    <EnvelopeDeCampo {...envelope}>
       <Input
-        id={id}
+        id={envelope.id}
         type={tipo}
         value={valor}
         onChange={(evento) =>
@@ -585,45 +602,54 @@ function CampoTexto({
         }
         readOnly={somenteLeitura}
         inputMode={modoEntrada}
-        aria-required={obrigatorio}
-        aria-invalid={erro ? true : undefined}
-        aria-describedby={erro ? `${id}-erro` : undefined}
+        {...atributosAcessiveis(envelope)}
       />
-      {dica && <p className="text-xs text-muted-foreground">{dica}</p>}
-      <MensagemErroCampo id={`${id}-erro`} erro={erro} />
-    </div>
+    </EnvelopeDeCampo>
   );
 }
 
-interface PropsCampoSelect {
-  id: string;
-  rotulo: string;
+interface PropsCampoTextoMultilinha extends PropsEnvelopeDeCampo {
+  valor: string;
+  aoAlterar: (valor: string) => void;
+}
+
+/** Texto livre multilinha; ocupa sempre a linha inteira da grade. */
+function CampoTextoMultilinha({
+  valor,
+  aoAlterar,
+  ...envelope
+}: PropsCampoTextoMultilinha) {
+  return (
+    <EnvelopeDeCampo {...envelope} larguraTotal>
+      <Textarea
+        id={envelope.id}
+        value={valor}
+        onChange={(evento) => aoAlterar(evento.target.value)}
+        {...atributosAcessiveis(envelope)}
+      />
+    </EnvelopeDeCampo>
+  );
+}
+
+interface PropsCampoSelect extends PropsEnvelopeDeCampo {
   valor: string;
   aoAlterar: (valor: string) => void;
   opcoes: readonly string[];
-  obrigatorio?: boolean;
-  erro?: string;
 }
 
 function CampoSelect({
-  id,
-  rotulo,
   valor,
   aoAlterar,
   opcoes,
-  obrigatorio = false,
-  erro,
+  ...envelope
 }: PropsCampoSelect) {
   return (
-    <div className="flex flex-col gap-1.5">
-      <RotuloCampo para={id} obrigatorio={obrigatorio} texto={rotulo} />
+    <EnvelopeDeCampo {...envelope}>
       <SelectNativo
-        id={id}
+        id={envelope.id}
         value={valor}
         onChange={(evento) => aoAlterar(evento.target.value)}
-        aria-required={obrigatorio}
-        aria-invalid={erro ? true : undefined}
-        aria-describedby={erro ? `${id}-erro` : undefined}
+        {...atributosAcessiveis(envelope)}
       >
         <option value="">Selecione…</option>
         {opcoes.map((opcao) => (
@@ -632,7 +658,56 @@ function CampoSelect({
           </option>
         ))}
       </SelectNativo>
-      <MensagemErroCampo id={`${id}-erro`} erro={erro} />
+    </EnvelopeDeCampo>
+  );
+}
+
+const idDaDica = (id: string) => `${id}-dica`;
+const idDoErro = (id: string) => `${id}-erro`;
+
+/**
+ * Atributos ARIA do controle: obrigatório, inválido e a descrição — dica e
+ * erro, na ordem em que aparecem na tela — para o leitor de tela ler junto
+ * com o rótulo.
+ */
+function atributosAcessiveis({
+  id,
+  obrigatorio = false,
+  dica,
+  erro,
+}: PropsEnvelopeDeCampo) {
+  const descricao = [dica && idDaDica(id), erro && idDoErro(id)]
+    .filter(Boolean)
+    .join(" ");
+  return {
+    "aria-required": obrigatorio,
+    "aria-invalid": erro ? true : undefined,
+    "aria-describedby": descricao === "" ? undefined : descricao,
+  };
+}
+
+/** Rótulo, controle, dica e mensagem de erro — a casca de todo campo. */
+function EnvelopeDeCampo({
+  id,
+  rotulo,
+  obrigatorio = false,
+  erro,
+  dica,
+  larguraTotal = false,
+  children,
+}: PropsEnvelopeDeCampo & { children: React.ReactNode }) {
+  return (
+    <div
+      className={cn("flex flex-col gap-1.5", larguraTotal && "md:col-span-2")}
+    >
+      <RotuloCampo para={id} obrigatorio={obrigatorio} texto={rotulo} />
+      {children}
+      {dica && (
+        <p id={idDaDica(id)} className="text-xs text-muted-foreground">
+          {dica}
+        </p>
+      )}
+      <MensagemErroCampo id={idDoErro(id)} erro={erro} />
     </div>
   );
 }

--- a/src/testes/fixtures-paciente.ts
+++ b/src/testes/fixtures-paciente.ts
@@ -22,6 +22,7 @@ export function dadosPacienteValidos(
     telefone1: "(11) 91234-5678",
     telefone2: null,
     email: "ana@exemplo.com",
+    motivoTerapia: "Ansiedade no trabalho, crises de choro",
     jaFezTerapia: false,
     quandoFezTerapia: null,
     tomaMedicamento: false,


### PR DESCRIPTION
## Resumo

Leva à `main` o trabalho da `dev`: o cadastro do Paciente passa a registrar o **Motivo da terapia** — por que a pessoa procurou terapia, com as próprias palavras — e a Consulta o mostra no cabeçalho (#30).

- **Banco e domínio**: migração 0004 adiciona `motivo_terapia` (nula, para os Pacientes anteriores ao campo não perderem nada); a obrigatoriedade é do domínio daqui para a frente, como nos condicionais clínicos. Ao editar um Paciente antigo, o campo abre vazio e precisa ser preenchido para salvar.
- **Formulário (desktop e tablet)**: seção própria "Motivo da terapia" entre Contato e Histórico clínico, texto livre multilinha de largura total — nenhum grupo existente muda de lugar. Dica "Conte com suas palavras…" só no Modo tablet. Nova primitiva `ui/textarea.tsx` (design.md 3.4) e um `EnvelopeDeCampo` comum aos campos, que leva a dica ao `aria-describedby`.
- **Servidor do Auto-cadastro**: campo obrigatório na rota REST — ausente ou em branco responde 422; o INSERT o grava.
- **Consulta**: linha própria no cabeçalho com o texto completo, somente leitura; Paciente sem motivo vê "Motivo da terapia não informado" com link para a edição do cadastro.
- **Docs**: spec 1.1, 1.3 e 2.3; termo canônico e termos a evitar no `CONTEXT.md`; ADRs intocados.
- **Lint**: `npm run lint` já falhava na `dev` desde o ícone (#26) por uma regra de SVG no arquivo fonte do ícone; commit à parte com um override do Biome só para essa regra em `src-tauri/icons/**`.

## Verificação

- `npm run lint` e `npx tsc --noEmit` limpos
- `npm run test:run`: 303 testes Vitest (+6)
- `cargo test`: 64 testes Rust (+2)

## Issues fechadas

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)
